### PR TITLE
Fix: StudyList및 StudyDetail우측 프로필 수정

### DIFF
--- a/src/components/StudyCard.tsx
+++ b/src/components/StudyCard.tsx
@@ -25,6 +25,27 @@ const countryCharacterImages: { [key: string]: string } = {
   CN: ChinaProfileImg,
 };
 
+const getCleanImageUrl = (url: string | null | undefined) => {
+  if (!url || url.trim() === "") return null;
+
+  const base = import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, "") || "";
+
+  // 중복 슬래시 정리
+  const cleaned = url.replace(/([^:]\/)\/+/g, "$1");
+
+  // 이미 절대경로인 경우
+  if (cleaned.startsWith("http")) {
+    const hasQuery = cleaned.includes("?");
+    return `${cleaned}${hasQuery ? "&" : "?"}t=${Date.now()}`;
+  }
+
+  // 상대경로인 경우 → BASE_URL 붙이기
+  const normalized = cleaned.replace(/^\//, "");
+  const full = base ? `${base}/${normalized}` : normalized;
+  const hasQuery = full.includes("?");
+  return `${full}${hasQuery ? "&" : "?"}t=${Date.now()}`;
+};
+
 const CardContainer = styled.div`
   background-color: var(--white);
   border: 1px solid var(--gray);
@@ -134,9 +155,9 @@ const StudyCard = ({ study, onClick, currentUserId, authorCountry }: StudyCardPr
       ]) ||
     KoreaProfileImg;
 
-  let characterImage: string | null = study.authorProfileImageUrl;
+  let characterImage: string | null = study.authorProfileImageUrl || null;
 
-  // 🔹 이 카드의 작성자가 "나"인 경우 + 기본이미지 모드면 → 업로드 이미지 무시
+  // 이 카드의 작성자가 "나"인 경우 + 기본이미지 모드면 → 업로드 이미지 무시
   if (
     currentUserId &&
     study.authorId === currentUserId &&
@@ -145,9 +166,13 @@ const StudyCard = ({ study, onClick, currentUserId, authorCountry }: StudyCardPr
     characterImage = null;
   }
 
-  const finalSrc = characterImage
-    ? characterImage.replace(/([^:]\/)\/+/g, "$1")
+  const finalSrc =
+  characterImage
+    ? getCleanImageUrl(characterImage) || fallbackCharacter
     : fallbackCharacter;
+
+    //마이페이지에서 기본 이미지로 되돌렸을 때 -> characterImage null 처리하면 fallbackCharacter로 교체~~
+  //제발 되자
   
   // 캠퍼스 
   const campusMap: { [key: string]: string } = {

--- a/src/pages/profile/ProfileList.tsx
+++ b/src/pages/profile/ProfileList.tsx
@@ -419,7 +419,19 @@ const ProfileList: React.FC = () => {
             ? `${profile.infoTitle}\n${profile.infoContent}`
             : ""
         }
-        onClick={() => handleProfileClick(profile.userId)}
+        onClick={() => {
+  if (profile.userId === currentUserId) {
+    // 자기 자신이면 마이페이지로 가라 ㅏ제발
+    navigate("/mypage");
+  } else {
+    // 남이면 기존처럼 프로필 상세
+    // 정말 재밌다
+    // 졸려요
+    // 이것만 하면 잔다!!!
+    // 아예 mypage로 이동되게끔 해서 따로 profileDetail에서는 수정 안할게요
+    handleProfileClick(profile.userId);
+  }
+}}
       />
     );
   })}

--- a/src/pages/study/StudyDetail.tsx
+++ b/src/pages/study/StudyDetail.tsx
@@ -34,6 +34,21 @@ import EgyptProfileImg from "../../assets/img-profile1-Egypt.svg";
 import ChinaProfileImg from "../../assets/img-profile1-China.svg";
 import axiosInstance from "../../../axiosInstance";
 
+const getCleanImageUrl = (url: string | null | undefined) => {
+  if (!url || url.trim() === "") return null;
+
+  const base = import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, "") || "";
+
+  // 절대 주소인 경우
+  if (url.startsWith("http")) {
+    return `${url.replace(/([^:]\/)\/+/g, "$1")}?t=${Date.now()}`;
+  }
+
+  // 상대 경로인 경우
+  const normalized = url.replace(/^\//, "").replace(/([^:]\/)\/+/g, "$1");
+  return base ? `${base}/${normalized}?t=${Date.now()}` : `${normalized}?t=${Date.now()}`;
+};
+
 
 // 국가별 캐릭터 이미지 매핑
 const countryCharacterImages: { [key: string]: string } = {
@@ -243,6 +258,14 @@ const JoinButton = styled.button`
   }
 `;
 
+const [authorProfile, setAuthorProfile] = useState<{
+  country: string | null;
+  profileImageUrl: string | null;
+} | null>(null);
+
+const [isAuthorProfileLoading, setIsAuthorProfileLoading] = useState(false);
+
+
 const StudyDetail = () => {
     const { id: postId } = useParams<{ id: string }>();
     const studyId = Number(postId);
@@ -266,8 +289,8 @@ const StudyDetail = () => {
   localStorage.getItem("useDefaultProfileImage") === "true";
 
     const effectiveUserProfileImageUrl =
-  useDefaultProfile ? null : userMe?.profileImageUrl ?? null;
-
+  useDefaultProfile ? null : getCleanImageUrl(userMe?.profileImageUrl);
+// 항상 최신 이미지로(내 프로필 이미지 캐시 깨기)
     
     useEffect(() => {
   const fetchUserMe = async () => {
@@ -298,7 +321,7 @@ const fetchComments = useCallback(async () => {
     const commentsWithAuthorInfo = await Promise.all(
       rawComments.map(async (comment: any) => {
         try {
-          // ⬇⬇⬇ 이게 정확한 댓글 작성자 정보 API 
+          // 댓글 작성자 정보 API 
           const profileRes = await axiosInstance.get(`/api/profiles/${comment.author.id}`);
 
           return {
@@ -332,6 +355,23 @@ const fetchComments = useCallback(async () => {
   }
 }, [studyId]);
 
+const fetchAuthorProfile = useCallback(async (authorId: number) => {
+  try {
+    setIsAuthorProfileLoading(true);
+    const res = await axiosInstance.get(`/api/profiles/${authorId}`);
+
+    setAuthorProfile({
+      country: res.data.country ?? null,
+      profileImageUrl: res.data.profileImageUrl ?? null,
+    });
+  } catch (e) {
+    console.error("작성자 프로필 조회 실패:", authorId, e);
+    setAuthorProfile(null);
+  } finally {
+    setIsAuthorProfileLoading(false);
+  }
+}, []);
+
 
 
 const fetchStudyDetail = useCallback(async () => {
@@ -341,13 +381,18 @@ const fetchStudyDetail = useCallback(async () => {
     const response: StudyDetailResponse = await getStudyDetail(studyId);
     setStudyDetail(response.data);
     setError(null);
+
+     if (response.data?.authorId) {
+      fetchAuthorProfile(response.data.authorId);
+    }
+
   } catch (err) {
     const errorMessage = handleApiError(err);
     setError(`게시글 정보를 불러오는데 실패했습니다: ${errorMessage}`);
   } finally {
     setIsLoading(false);
   }
-}, [studyId]);
+}, [studyId, fetchAuthorProfile]);
 
 useEffect(() => {
   fetchStudyDetail();
@@ -519,9 +564,10 @@ useEffect(() => {
     const isAuthor = currentUserId != null && studyData.authorId === currentUserId;
       
     const authorCountryCode =
+    authorProfile?.country ||
   (studyData as any).authorCountry ||
   (studyData as any).authorNation ||
-  userMe?.country; // 없으면 내 country라도 사용
+    "KR";// 없으면 KR 기본(이러며 ㄴ안되긴하는데)
 
     const fallbackCharacter =
   (authorCountryCode &&
@@ -534,14 +580,24 @@ useEffect(() => {
 
   if (isAuthor) {
   if (useDefaultProfile || !userMe?.profileImageUrl) {
-    // 기본이미지 모드 → fallback 사용
+    // 기본이미지 모드 or 서버에 이미지 없음 → 내 country기반 이미지 사용
     characterImage = fallbackCharacter;
-  } else if (userMe.profileImageUrl) {
-    characterImage = userMe.profileImageUrl;
+  } else {
+    // 내 업로드 이미지 + 캐시 버스터
+    characterImage = getCleanImageUrl(userMe.profileImageUrl) || fallbackCharacter;
   }
-} else if (studyData.authorProfileImageUrl) {
-  // 남이 쓴 글이면 서버에서 온 authorProfileImageUrl 그대로
-  characterImage = studyData.authorProfileImageUrl;
+} else {
+  // 다른 사람이 쓴 글
+  const uploadedAuthorImage =
+    authorProfile?.profileImageUrl || studyData.authorProfileImageUrl;
+
+  if (uploadedAuthorImage) {
+    characterImage = getCleanImageUrl(uploadedAuthorImage) || fallbackCharacter;
+  } else {
+    // 업로드 이미지 없으면 나라 기반 기본 캐릭터(fallbackCharacter)
+    // 마이페이지에서 기본 이미지로 되돌렸을 때 -> characterImage null 처리하면 fallbackCharacter로 교체~~
+    characterImage = fallbackCharacter;
+  }
 }
 
   // 혹시 모르니 슬래시 정리

--- a/src/pages/study/StudyList.tsx
+++ b/src/pages/study/StudyList.tsx
@@ -260,6 +260,8 @@ const StudyList = () => {
   const [isLoading, setIsLoading] = useState(true); // 로딩 상태
   const [error, setError] = useState<string | null>(null); // 에러 메시지
 
+  const storedUserId = Number(localStorage.getItem("userId")) || undefined;
+// gk currentUserId를 로컬스토리지 기반으로 넘겨주기
   const fetchStudies = useCallback(async (customFilter?: StudyFilter) => {
     setIsLoading(true);
     setError(null);
@@ -535,7 +537,7 @@ useEffect(() => {
               study={study}
               authorCountry={study.authorCountry}  
               onClick={() => handleStudyClick(study.id)}
-              currentUserId={userMe?.id}
+              currentUserId={storedUserId} // useDefaultProfileImage가 true로 켜지고 기본으로 되돌리면 fallbackCharater로 바뀌어서 내가 쓴 스터디리스트에도 전부 기본 캐릭터로 보임
             />
               ))
             )}


### PR DESCRIPTION
* 이슈1.
StudyList에서 내 프로필을 다시 기본이미지로 돌렸을 때 우측에 내가 올린 스터디게시글에서 나의 이미지가 기본이미지로 다시 돌아가지 않고 이전에 올린 이미지랑 동일하다
*이슈2.
StudyDetail 우측 상단 프로필은 여전히 게시글 작성자의 이미지가 아닌 현재 나의 기본이미지로 등록되어있음(게시글 작성자의 이미지가 기본이미지가 아닌 따로 업로드한 이미지면 또 잘 보임. 근데 게시글 작성자가 기본이미지로 그냥 놔뒀거나 혹시 변경했다면 기본이미지가 내 기본이미지로 나오는듯)

= 해결 : fallback함수 설정 추가