### PR TITLE
fix: 로그아웃 오류 해결 

### DIFF
--- a/src/components/CommentSection.tsx
+++ b/src/components/CommentSection.tsx
@@ -36,7 +36,7 @@ const getCommentProfileImage = (
   const useDefaultProfile =
     localStorage.getItem("useDefaultProfileImage") === "true";
 
-  const country = (comment.author as any).country as string | undefined;
+  const country = comment.author.country;
   const fallbackCharacter = country && countryCharacterImages[country]
     ? countryCharacterImages[country]
     : KoreaProfileImg;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -68,8 +68,13 @@ export default function Header() {
   
 
     const handleLogout = async () => {
+
+      const refreshToken = localStorage.getItem("refreshToken");
+
       try {
-        await axiosInstance.post("/api/auth/logout");
+        if (refreshToken) {
+          await axiosInstance.post("/api/auth/logout", { refreshToken });
+        }
         alert("로그아웃되었습니다.");
       } catch (e) {
         alert("로그아웃 처리 중 문제가 발생했습니다.");

--- a/src/types/study.types.ts
+++ b/src/types/study.types.ts
@@ -61,6 +61,7 @@ export interface CommentAuthor {
   id: number; 
   nickname: string;
   profileImageUrl: string | null;
+  country: string;
 }
 
 // 댓글 


### PR DESCRIPTION
## 📌 PR 개요
- 로그아웃 API 호출 시 리프레시 토큰이 전송되지 않아 발생하던 오류 수정
- 스웨거에서는 정상 작동하지만 로컬 환경에서 "문제가 발생했습니다" 에러가 발생하던 문제 해결

## 🔗 관련 이슈
- close #154  

## 🛠 변경 내용
- **Header.tsx** `handleLogout` 함수 수정
  - 로그아웃 API 요청 전에 `localStorage`에서 리프레시 토큰을 미리 가져오도록 수정
  - 리프레시 토큰을 요청 본문(`{ refreshToken }`)에 포함하여 전송하도록 수정
  - 리프레시 토큰이 있을 때만 로그아웃 API를 호출하도록 조건 추가
  - `finally` 구문을 통해 성공/실패와 관계없이 로컬 스토리지 정리 및 상태 업데이트 보장

## 📝 해결방법
- 로그아웃 API는 리프레시 토큰을 요구하는데, 기존 코드는 리프레시 토큰을 요청 바디에 포함하지 않고 API를 호출함
- 로그아웃 API 요청 전에 `localStorage`에서 리프레시 토큰을 가져와 요청 바디(`{ refreshToken }`)에 포함하여 전송하도록 수정
