### PR TITLE
fix:이메일 인증 플로우 개선 및 공통 모달 컴포넌트 추가

### DIFF
--- a/src/components/EmailVerificationModal.tsx
+++ b/src/components/EmailVerificationModal.tsx
@@ -1,0 +1,163 @@
+import styled from "styled-components";
+import type { FC, ChangeEvent } from "react";
+
+const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.18);
+  z-index: 9999;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ModalContainer = styled.div`
+  position: relative;
+  width: 32rem;
+  min-height: 18rem;
+  padding: 2.5rem 2.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: white;
+  border-radius: 1rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  z-index: 10000;
+`;
+
+const CodeInputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.06rem;
+  width: 100%;
+`;
+
+const ModalContent = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+`;
+
+const CodeInputBox = styled.div`
+  display: flex;
+  height: 4.5rem;
+  border-bottom: 0.0625rem solid #ababab;
+  box-sizing: border-box;
+  width: 100%;
+`;
+
+const CodeInputTitle = styled.div`
+  width: 10.25rem;
+  padding-left: 0.69rem;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+`;
+
+const CodeInputItem = styled.input`
+  border: none;
+  flex: 1;
+  &::placeholder {
+    font-size: 1rem;
+    font-weight: 500;
+    color: #b1b1b1;
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const VerificationButton = styled.div`
+  display: flex;
+  width: 7.69rem;
+  height: 2.44rem;
+  justify-content: center;
+  align-items: center;
+  border-radius: 0.75rem;
+  background-color: var(--primary);
+  color: var(--white);
+  cursor: pointer;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 2rem;
+`;
+
+type EmailVerificationModalProps = {
+  isOpen: boolean;
+  email?: string | null;
+  verificationCode: string;
+  onChangeCode: (e: ChangeEvent<HTMLInputElement>) => void;
+  onVerify: () => void;
+  onResend: () => void;
+  message?: string;
+};
+
+const EmailVerificationModal: FC<EmailVerificationModalProps> = ({
+  isOpen,
+  email,
+  verificationCode,
+  onChangeCode,
+  onVerify,
+  onResend,
+  message = "이메일로 인증번호가 전송되었습니다!",
+}) => {
+  if (!isOpen) return null;
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // 모달 컨테이너를 클릭한 경우가 아니면 무시 (배경 클릭 방지)
+    if (e.target === e.currentTarget) {
+      // 배경 클릭을 막기 위해 아무 동작도 하지 않음
+      return;
+    }
+  };
+
+  return (
+    <Backdrop onClick={handleBackdropClick}>
+      <ModalContainer onClick={(e) => e.stopPropagation()}>
+        <CodeInputContainer>
+          <ModalContent>
+            <p style={{ fontSize: "1.125rem", fontWeight: 500, marginBottom: "0.5rem", textAlign: "center" }}>
+              {message}
+            </p>
+            {email && (
+              <p style={{ fontSize: "0.875rem", color: "#666", marginBottom: "0.5rem" }}>
+                {email}
+              </p>
+            )}
+            <CodeInputBox>
+              <CodeInputTitle className="Body1">인증 번호</CodeInputTitle>
+              <CodeInputItem
+                type="text"
+                placeholder="인증번호를 입력하세요"
+                value={verificationCode}
+                onChange={onChangeCode}
+              />
+            </CodeInputBox>
+
+            <ButtonWrapper>
+              <VerificationButton className="Button2" onClick={onVerify}>
+                인증번호 확인
+              </VerificationButton>
+              <VerificationButton className="Button2" onClick={onResend}>
+                인증번호 재전송
+              </VerificationButton>
+            </ButtonWrapper>
+          </ModalContent>
+        </CodeInputContainer>
+      </ModalContainer>
+    </Backdrop>
+  );
+};
+
+export default EmailVerificationModal;
+

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,8 +2,9 @@ import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import Logo from "../assets/logo.svg";
 import CharacterBlur from "../assets/character-blur.svg";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import axiosInstance from "../../axiosInstance";
+import EmailVerificationModal from "../components/EmailVerificationModal";
 
 const Container = styled.div`
   width: 100%;
@@ -118,7 +119,21 @@ const Login = () => {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
- 
+  const [isVerificationModalOpen, setIsVerificationModalOpen] = useState(false);
+  const [verificationCode, setVerificationCode] = useState("");
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
+
+  // 페이지 로드 시 localStorage에서 미인증 이메일 확인
+  useEffect(() => {
+    const pendingEmailFromStorage = localStorage.getItem("pendingVerificationEmail");
+    if (pendingEmailFromStorage) {
+      setPendingEmail(pendingEmailFromStorage);
+      if (!email) {
+        setEmail(pendingEmailFromStorage);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleLogin = async () => {
     if (!username || !email || !password) {
@@ -138,17 +153,104 @@ const Login = () => {
       localStorage.setItem("accessToken", accessToken);
       localStorage.setItem("refreshToken", refreshToken);
       localStorage.setItem("userId", response.data.userId);
+      // 로그인 성공 시 미인증 이메일 정보 제거
+      localStorage.removeItem("pendingVerificationEmail");
 
       alert("로그인 성공!");
       console.log("로그인 응답:", response);
       navigate("/");
     } catch (error: any) {
       console.error("로그인 실패:", error);
+
+      // 에러 메시지에서 이메일 인증 관련 키워드 확인
+      const errorMessage = error.response?.data?.message || "";
+      const isVerificationError =
+        errorMessage.includes("인증") ||
+        errorMessage.includes("verification") ||
+        errorMessage.includes("unverified") ||
+        errorMessage.includes("이메일") ||
+        error.response?.status === 403;
+
+      // 이메일 인증이 필요한 경우 모달 표시
+      if (isVerificationError && email) {
+        setPendingEmail(email);
+        localStorage.setItem("pendingVerificationEmail", email);
+        setIsVerificationModalOpen(true);
+        return;
+      }
+
       if (error.response?.status === 401) {
         alert("아이디 또는 비밀번호가 올바르지 않습니다.");
       } else {
-        alert("로그인 중 오류가 발생했습니다.");
+        alert(errorMessage || "로그인 중 오류가 발생했습니다.");
       }
+    }
+  };
+
+  const handleVerifyCode = async () => {
+    if (!verificationCode.trim()) {
+      alert("인증번호를 입력해주세요!");
+      return;
+    }
+
+    if (!pendingEmail) {
+      alert("이메일 정보를 찾을 수 없습니다.");
+      return;
+    }
+
+    try {
+      const verifyData = {
+        email: pendingEmail,
+        code: verificationCode,
+      };
+
+      console.log("인증 요청 데이터:", verifyData);
+
+      const res = await axiosInstance.post("/api/auth/verify-code", verifyData);
+
+      if (res.data.verified) {
+        alert("이메일 인증이 완료되었습니다!");
+        setIsVerificationModalOpen(false);
+        setVerificationCode("");
+        // 인증 완료 시 localStorage에서 제거
+        localStorage.removeItem("pendingVerificationEmail");
+        setPendingEmail(null);
+        // 인증 완료 후 자동으로 로그인 시도
+        if (username && password) {
+          handleLogin();
+        }
+      } else {
+        alert("인증에 실패했습니다. 코드를 다시 확인해주세요.");
+      }
+    } catch (error: any) {
+      console.error("인증 실패:", error.response?.data || error.message || error);
+      alert(error.response?.data?.message || "인증 중 오류가 발생했습니다.");
+    }
+  };
+
+  const handleResendCode = async () => {
+    if (!pendingEmail) {
+      alert("이메일 정보를 찾을 수 없습니다.");
+      return;
+    }
+
+    try {
+      const resendData = {
+        email: pendingEmail,
+      };
+
+      console.log("인증번호 재전송 요청 데이터:", resendData);
+
+      const res = await axiosInstance.post("/api/auth/verification/resend", resendData);
+
+      if (res.data.ok) {
+        alert("인증번호가 재전송되었습니다. 메일함을 다시 확인해주세요!");
+      } else {
+        alert("재전송에 실패했습니다. 다시 시도해주세요.");
+      }
+    } catch (error: any) {
+      console.error("인증번호 재전송 실패:", error.response?.data || error.message || error);
+      alert(error.response?.data?.message || "인증번호 재전송 중 오류가 발생했습니다.");
     }
   };
 
@@ -162,6 +264,32 @@ const Login = () => {
       </IntroContainer>
       <LoginContainer>
         <LoginTitle>로그인</LoginTitle>
+        {pendingEmail && (
+          <div
+            style={{
+              fontSize: "0.875rem",
+              color: "var(--primary)",
+              marginBottom: "1rem",
+              textAlign: "center",
+              padding: "0.5rem",
+              backgroundColor: "rgba(255, 230, 162, 0.2)",
+              borderRadius: "0.5rem",
+            }}
+          >
+            이메일 인증이 완료되지 않았습니다. ({pendingEmail})<br />
+            이메일 인증을 완료해주세요.{" "}
+            <span
+              onClick={() => setIsVerificationModalOpen(true)}
+              style={{
+                cursor: "pointer",
+                textDecoration: "underline",
+                fontWeight: 500,
+              }}
+            >
+              완료하기
+            </span>
+          </div>
+        )}
         <InputContainer>
           <InputBox>
             <InputTitle >아이디</InputTitle>
@@ -189,11 +317,22 @@ const Login = () => {
           </InputBox>
           <SumbitContainer>
             <SubmitButton onClick={handleLogin}>로그인</SubmitButton>
-            <SignUpContent onClick={() => navigate("/signup/step1")}>회원이 아니신가요? <span style={{color:"var(--primary)", cursor:"pointer"}} >회원가입</span></SignUpContent>
+            <SignUpContent onClick={() => navigate("/signup/step1")}>
+              회원이 아니신가요?{" "}
+              <span style={{color:"var(--primary)", cursor:"pointer"}} >회원가입</span>
+            </SignUpContent>
           </SumbitContainer>
           
         </InputContainer>
       </LoginContainer>
+      <EmailVerificationModal
+        isOpen={isVerificationModalOpen}
+        email={pendingEmail}
+        verificationCode={verificationCode}
+        onChangeCode={(e) => setVerificationCode(e.target.value)}
+        onVerify={handleVerifyCode}
+        onResend={handleResendCode}
+      />
     </Container>
   );
 };

--- a/src/pages/signup/SignUp4.tsx
+++ b/src/pages/signup/SignUp4.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axiosInstance from "../../../axiosInstance";
 import { useSignup } from "../../contexts/SignupContext";
+import EmailVerificationModal from "../../components/EmailVerificationModal";
 
 const Container = styled.div`
   width: 100%;
@@ -171,72 +172,6 @@ const KeywordItem = styled.div`
 
 `
 
-const ModalContainer = styled.div`
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%); 
-  width: 43.25rem;
-  height: 22.375rem; 
-  padding: 0 3.875rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: white; 
-  border-radius: 1rem; 
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
-  z-index: 10000;
-`;
-
- const CodeInputContainer = styled.div`
- display: flex;
- flex-direction: column;
- align-items: center;
- gap: 1.06rem;
-`
-const CodeInputBox = styled.div`
-  display: flex;
-  height: 4.5rem;
-  border-bottom: 0.0625rem solid #ABABAB;
-  box-sizing: border-box;
-`
-
-const CodeInputTitle = styled.div`
-  width: 10.25rem;
-  padding-left: 0.69rem;
-  font-weight: 500;
-  display: flex;
-  align-items: center;
-`
-const CodeInputItem = styled.input`
-  border: none;
-  width: 9.88rem;
-  &::placeholder {
-    font-size: 1rem;
-    font-weight: 500;
-    color: #B1B1B1;
-  }
-
-  &:focus {
-    outline: none; 
-  }
-`
-const VerificationButton = styled.div`
-  display: flex;
-  width: 7.69rem;
-  height: 2.44rem;
-  justify-content: center;
-  align-items: center;
-  border-radius: 0.75rem;
-  background-color: var(--primary);
-  color: var(--white);
-`
-const ButtonWraaper = styled.div`
-display: flex;
-flex-direction: row;
-gap: 2rem;
-`
-
 const SignUp4 = () => {
 
   const navigate = useNavigate();
@@ -293,6 +228,10 @@ const SignUp4 = () => {
   
       console.log("회원가입 성공:", response.data);
      
+      if (signupData.email) {
+        localStorage.setItem("pendingVerificationEmail", signupData.email);
+      }
+     
       setIsModalOpen(true);
     } catch (error: any) {
       console.error("회원가입 실패:", error.response?.data || error.message || error);
@@ -323,6 +262,8 @@ const SignUp4 = () => {
         alert("이메일 인증이 완료되었습니다!");
         setIsVerified(true);
         setIsModalOpen(false);
+        // 이메일 인증 완료 시 localStorage에서 제거
+        localStorage.removeItem("pendingVerificationEmail");
         navigate("/login"); 
       } else {
         alert("인증에 실패했습니다. 코드를 다시 확인해주세요.");
@@ -472,32 +413,14 @@ const handleResendCode = async () => {
           <SubmitButton onClick={handleSubmit} /> 
       </ContentContainer>
 
-      {isModalOpen && (
-      <ModalContainer>
-        <CodeInputContainer>
-          <p>이메일로 인증번호가 갔습니다!</p>
-          <CodeInputBox>
-            <CodeInputTitle className="Body1">인증 번호</CodeInputTitle>
-            <CodeInputItem
-                type="text"
-                placeholder="인증번호를 입력하세요"
-                value={verificationCode}
-                onChange={(e) => setVerificationCode(e.target.value)} 
-              />
-          </CodeInputBox>
-
-          <ButtonWraaper>
-            <VerificationButton className="Button2" onClick={handleVerifyCode}>
-              인증번호 확인
-            </VerificationButton>
-            <VerificationButton className="Button2" onClick={handleResendCode} >
-              인증번호 재전송
-            </VerificationButton>
-          </ButtonWraaper>
-
-        </CodeInputContainer>
-      </ModalContainer>
-      )}
+      <EmailVerificationModal
+        isOpen={isModalOpen}
+        email={signupData.email}
+        verificationCode={verificationCode}
+        onChangeCode={(e) => setVerificationCode(e.target.value)}
+        onVerify={handleVerifyCode}
+        onResend={handleResendCode}
+      />
      
 
     </Container>


### PR DESCRIPTION
## 📌 PR 개요
- 회원가입 후 이메일 인증 팝업을 닫거나 화면을 이탈한 사용자가 다시 접속했을 때도 이메일 인증을 완료할 수 있도록 플로우를 개선.
- 이메일 인증 모달을 공통 컴포넌트로 분리하여 재사용성을 높이고, UI/UX를 개선

## 🔗 관련 이슈
closes #155 

## 🛠 변경 내용

### 신규 컴포넌트
- **`FE/src/components/EmailVerificationModal.tsx`** 추가
  - 이메일 인증 모달 공통 컴포넌트
  - 인증 안내 메시지, 이메일 표시, 인증번호 입력 필드, 확인/재전송 버튼 포함
  - 반투명 어두운 배경 오버레이 적용 (배경 클릭 방지)

### 수정된 파일
- **`FE/src/pages/signup/SignUp4.tsx`**
  - 회원가입 성공 시 `localStorage`에 `pendingVerificationEmail` 저장
  - 기존 인라인 모달 코드를 `EmailVerificationModal` 컴포넌트로 교체
  - 이메일 인증 완료 시 `localStorage`에서 `pendingVerificationEmail` 제거

- **`FE/src/pages/Login.tsx`**
  - 페이지 마운트 시 `localStorage.pendingVerificationEmail` 확인
  - 미인증 이메일이 있으면 상단에 안내 배너 표시
  - 안내 배너의 "완료하기" 텍스트 클릭 시 인증 모달 오픈
  - 로그인 실패 시 이메일 인증 관련 에러 감지하여 모달 자동 오픈
  - 로그인 성공 시 `pendingVerificationEmail` 제거

### 주요 로직
- `localStorage`를 활용한 미인증 이메일 상태 관리
- 회원가입/로그인 페이지에서 동일한 인증 모달 컴포넌트 재사용
- 백엔드 API 변경 없이 프론트엔드에서만 처리

## 📝 비고
- 백엔드 로직은 변경하지 않았으며, 프론트엔드에서만 처리
- 향후 모달 닫기 버튼 추가 또는 ESC 키로 모달 닫기 기능 추가 검토 가능