### PR TITLE
Fix/mypage profile

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -52,6 +52,7 @@ const countryCharacterImages: { [key: string]: string } = {
   KR: KoreaProfileImg,
   IT: ItalyProfileImg,
   AR: EgyptProfileImg,
+  EG: EgyptProfileImg,
   CN: ChinaProfileImg,
 };
 
@@ -386,8 +387,9 @@ const ProfileCard = ({
   const [editedData, setEditedData] = useState({
     infoTitle: infoTitle || "",
     infoContent: infoContent || "",
-    profileImage: profileImageUrl || null,
+    profileImage: null,
   });
+
 
   useEffect(() => {
     setEditedData(prev => ({
@@ -432,8 +434,8 @@ const ProfileCard = ({
     setOpenDropdown(null);
   };
 
-  const characterImage =
-    profileImageUrl || countryCharacterImages[country] || "https://via.placeholder.com/200";
+  // const characterImage =
+  //   profileImageUrl || countryCharacterImages[country] || "https://via.placeholder.com/200";
 
 
     const extractKeywords = (keywords: any) => {
@@ -534,12 +536,30 @@ const [editedMbti, setEditedMbti] = useState(mbti);
     },
   ];
 
+  // 2) country 정규화: 공백 제거 + 대문자 + 기본 KR
+const normalizedCountry = (country ?? "KR").trim().toUpperCase();
+
+// 3) 기본이미지 선택: 매핑 실패해도 KR로 떨어지게
+const defaultCountryImg =
+  countryCharacterImages[normalizedCountry] || KoreaProfileImg;
+
+// 4) 최종 표시 src: 업로드 이미지가 있으면 그걸, 없으면 국가 기본
+const displayImageSrc = profileImageUrl || defaultCountryImg;
+
+// 최종 이미지 src (여기에 추가)
+const imgSrc = editedData.profileImage || displayImageSrc;
+console.log("[ProfileCard] country(raw):", country);
+console.log("[ProfileCard] profileImageUrl(prop):", profileImageUrl);
+console.log("[ProfileCard] imgSrc(final):", imgSrc);
+// 해당 콘솔 나중에 지우기(서버 forbidden 이슈)
+
+
   return (
     <Card $isEditMode={isEditMode}>
       <TopSection>
       <LeftSection>
         <CharacterImage
-          src={editedData.profileImage || characterImage}
+          src={imgSrc}
           alt="프로필 이미지"
           onClick={() => {
             if (isOwner && isEditMode) {
@@ -570,12 +590,13 @@ const [editedMbti, setEditedMbti] = useState(mbti);
               }));
               
             }
+              e.currentTarget.value = ""; //두번째 클릭 이슈 방지
           }}
         />
 
         {/* 이미지 리셋 버튼 추가*/}
 
-        {isOwner && isEditMode && onImageReset && (
+        {/* {isOwner && isEditMode && onImageReset && (
           <div
             style={{
               marginTop: "0.5rem",
@@ -598,7 +619,7 @@ const [editedMbti, setEditedMbti] = useState(mbti);
              기본 이미지로 되돌리기
             </button>
           </div>
-        )}
+        )} */}
 
 
       <UserInfo>

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -215,6 +215,7 @@ const Mypage = () => {
     // 3) 내 정보 다시 불러오기
     const refreshed = await axiosInstance.get("/api/users/me");
     const refreshedUser = refreshed.data;
+    console.log("리셋 후 서버 profileImageUrl:", refreshedUser.profileImageUrl);
 
     // 🔹 로컬스토리지 플래그는 건드리지 않음
     // 대신, 플래그 값에 따라 보여줄 URL만 조정
@@ -260,9 +261,8 @@ const Mypage = () => {
       const formData = new FormData();
       formData.append("file", file);
   
-      await axiosInstance.post("/api/users/me/profile-image", formData, {
-        headers: { "Content-Type": "multipart/form-data" },
-      });
+      await axiosInstance.post("/api/users/me/profile-image", formData
+      );
 
       localStorage.setItem("useDefaultProfileImage", "false");
   
@@ -287,61 +287,61 @@ const Mypage = () => {
     }
   };
   // 이미지 리셋 핸들러 추가(이미지 삭제 할 수 있도록)
-   const handleProfileImageReset = async () => {
-    if (!userData) return;
+  //  const handleProfileImageReset = async () => {
+  //   if (!userData) return;
 
-    if (!window.confirm("업로드한 프로필 이미지를 삭제하고 기본 이미지로 되돌릴까요?")) {
-      return;
-    }
+  //   if (!window.confirm("업로드한 프로필 이미지를 삭제하고 기본 이미지로 되돌릴까요?")) {
+  //     return;
+  //   }
 
-    try {
-      // 현재 state에 있는 값들 그대로 보내고, profileImageUrl만 null로 바꿔서 보낸다.
-      const finalData = {
-        name: userData.name,
-        nickname: userData.nickname,
-        mbti: userData.mbti,
-        profileImageUrl: null, // 이미지 제거
-        infoTitle: userData.infoTitle,
-        infoContent: userData.infoContent,
-        campus: userData.campus,
-        country: userData.country,
-        email: userData.email,
-        nativeLanguages: languages.nativeCodes,
-        learnLanguages: languages.learnCodes,
-        personalityKeywords: keywords.personality,
-        hobbyKeywords: keywords.hobby,
-        topicKeywords: keywords.topic,
-      };
+  //   try {
+  //     // 현재 state에 있는 값들 그대로 보내고, profileImageUrl만 null로 바꿔서 보낸다.
+  //     const finalData = {
+  //       name: userData.name,
+  //       nickname: userData.nickname,
+  //       mbti: userData.mbti,
+  //       profileImageUrl: null, // 이미지 제거
+  //       infoTitle: userData.infoTitle,
+  //       infoContent: userData.infoContent,
+  //       campus: userData.campus,
+  //       country: userData.country,
+  //       email: userData.email,
+  //       nativeLanguages: languages.nativeCodes,
+  //       learnLanguages: languages.learnCodes,
+  //       personalityKeywords: keywords.personality,
+  //       hobbyKeywords: keywords.hobby,
+  //       topicKeywords: keywords.topic,
+  //     };
 
-      await axiosInstance.patch("/api/users/me", finalData);
+  //     await axiosInstance.patch("/api/users/me", finalData);
 
-      // 다시 내 정보 불러오기
-      const refreshed = await axiosInstance.get("/api/users/me");
-      const refreshedUser = refreshed.data;
+  //     // 다시 내 정보 불러오기
+  //     const refreshed = await axiosInstance.get("/api/users/me");
+  //     const refreshedUser = refreshed.data;
 
-      localStorage.setItem("useDefaultProfileImage", "true");
+  //     localStorage.setItem("useDefaultProfileImage", "true");
 
-      refreshedUser.profileImageUrl = null; //강제로 되돌리기(백에서 null 안줘도 프론트에서 처리)
+  //     refreshedUser.profileImageUrl = null; //강제로 되돌리기(백에서 null 안줘도 프론트에서 처리)
 
-      setUserData(refreshedUser);
-      setLanguages({
-        nativeCodes: refreshedUser.nativeLanguages || [],
-        learnCodes: refreshedUser.learnLanguages || [],
-      });
-      setKeywords({
-        personality: refreshedUser.personalityKeywords || [],
-        hobby: refreshedUser.hobbyKeywords || [],
-        topic: refreshedUser.topicKeywords || [],
-      });
+  //     setUserData(refreshedUser);
+  //     setLanguages({
+  //       nativeCodes: refreshedUser.nativeLanguages || [],
+  //       learnCodes: refreshedUser.learnLanguages || [],
+  //     });
+  //     setKeywords({
+  //       personality: refreshedUser.personalityKeywords || [],
+  //       hobby: refreshedUser.hobbyKeywords || [],
+  //       topic: refreshedUser.topicKeywords || [],
+  //     });
 
 
 
-      alert("프로필 이미지를 삭제하고 기본 이미지로 되돌렸습니다.");
-    } catch (error) {
-      console.error("프로필 이미지 기본이미지로 되돌리기 실패:", error);
-      alert("이미지 초기화 중 오류가 발생했습니다.");
-    }
-  };
+  //     alert("프로필 이미지를 삭제하고 기본 이미지로 되돌렸습니다.");
+  //   } catch (error) {
+  //     console.error("프로필 이미지 기본이미지로 되돌리기 실패:", error);
+  //     alert("이미지 초기화 중 오류가 발생했습니다.");
+  //   }
+  // };
 
   const handlePostClick = (postId: number) => {
     navigate(`/study/${postId}`);
@@ -427,7 +427,7 @@ const Mypage = () => {
               onSave={handleProfileSave}
               onCancel={() => setIsEditMode(false)}
               onImageUpload={handleProfileImageUpload}
-              onImageReset={handleProfileImageReset} 
+              // onImageReset={handleProfileImageReset} 
             />
           );
         })()

--- a/src/pages/study/StudyList.tsx
+++ b/src/pages/study/StudyList.tsx
@@ -527,7 +527,7 @@ useEffect(() => {
 
           <StudyListContainer>
             {studies.length === 0 && !isLoading ? (
-              <div style={{ padding: '4rem', textAlign: 'center' }}>검색 결과가 없습니다.</div>
+              <div style={{ padding: '4rem', textAlign: 'center' }}>모집하는 스터디가 없어요.</div>
             ) : (
               studies.map((study) => (
             <StudyCard 


### PR DESCRIPTION
## 📌 PR 개요
- 마이페이지 프로필 이미지 오류 수정
- 마이페이지 프로필 업로드 첫번째 시도 시 alert창 뜨는 오류 수정
## 🔗 관련 이슈
- close #162
- 이슈번호 project 투두에 안하고 올려서 거기에 올리고 수정할게요!!

## 🛠 변경 내용
- 프로필이미지(기본) 오류 - 마이페이지 상단 카드에 안불러와짐
- 프로필이미지(변경) 오류 - 마이페이지 상단 카드에 적용 안됨
- 프로필이미지(변경) 오류 - 마이페이지에서 클릭하고 처음에는 "이미지 변경 중 오류가 났습니다" alert 뜨고 적용 안됨. 두번째 클릭하고 변경해야 변경했다고 인식하긴하지만 여전히 프로필은 적용안되는 상태임.
- 기본 이미지로 되돌리기 버튼 임시 삭제
- 스터디 목록 페이지 : 검색 결과가 없습니다. -> 찾으시는 스터디가 없어요. 로 멘트 수정
- 
## 🧪 확인 사항
- [ 0] 로컬에서 정상 동작 확인
- [ 0] 타입 에러 없음
- [ 0] 기존 기능 정상 동작 유지
- [ 0] 불필요한 API 호출 없음

## 📝 비고
- 추후 작업 예정 사항
- 이미지 변경 시 콘솔에 403 forbidden 에러 찍힘 - 서버 public 으로 해야 제대로 나올거같아서 우선 백엔드에 확인 부탁드려야될거같음
(현재 이미지 url은 response에 잘 찍힘)