### PR TITLE
fix: 프로필(기본, 업로드) 이슈 해결 및 axiosInstance 수정

### DIFF
--- a/axiosInstance.ts
+++ b/axiosInstance.ts
@@ -14,6 +14,13 @@ axiosInstance.interceptors.request.use((config) => {
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
+
+  if (config.data instanceof FormData) {
+    delete config.headers["Content-Type"];
+  } else {
+    config.headers["Content-Type"] = "application/json";
+  }
+
   return config;
 });
 

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -52,7 +52,6 @@ const countryCharacterImages: { [key: string]: string } = {
   KR: KoreaProfileImg,
   IT: ItalyProfileImg,
   AR: EgyptProfileImg,
-  EG: EgyptProfileImg,
   CN: ChinaProfileImg,
 };
 
@@ -387,9 +386,8 @@ const ProfileCard = ({
   const [editedData, setEditedData] = useState({
     infoTitle: infoTitle || "",
     infoContent: infoContent || "",
-    profileImage: null,
+    profileImage: profileImageUrl || null,
   });
-
 
   useEffect(() => {
     setEditedData(prev => ({
@@ -434,8 +432,8 @@ const ProfileCard = ({
     setOpenDropdown(null);
   };
 
-  // const characterImage =
-  //   profileImageUrl || countryCharacterImages[country] || "https://via.placeholder.com/200";
+  const characterImage =
+    profileImageUrl || countryCharacterImages[country] || "https://via.placeholder.com/200";
 
 
     const extractKeywords = (keywords: any) => {
@@ -531,35 +529,17 @@ const [editedMbti, setEditedMbti] = useState(mbti);
     {
       icon: EmailIcon,
       label: "이메일",
-      value: email || "이메일은 비밀~",
+      value: email || "이메일은 비밀이에요",
       editable: false,
     },
   ];
-
-  // 2) country 정규화: 공백 제거 + 대문자 + 기본 KR
-const normalizedCountry = (country ?? "KR").trim().toUpperCase();
-
-// 3) 기본이미지 선택: 매핑 실패해도 KR로 떨어지게
-const defaultCountryImg =
-  countryCharacterImages[normalizedCountry] || KoreaProfileImg;
-
-// 4) 최종 표시 src: 업로드 이미지가 있으면 그걸, 없으면 국가 기본
-const displayImageSrc = profileImageUrl || defaultCountryImg;
-
-// 최종 이미지 src (여기에 추가)
-const imgSrc = editedData.profileImage || displayImageSrc;
-console.log("[ProfileCard] country(raw):", country);
-console.log("[ProfileCard] profileImageUrl(prop):", profileImageUrl);
-console.log("[ProfileCard] imgSrc(final):", imgSrc);
-// 해당 콘솔 나중에 지우기(서버 forbidden 이슈)
-
 
   return (
     <Card $isEditMode={isEditMode}>
       <TopSection>
       <LeftSection>
         <CharacterImage
-          src={imgSrc}
+          src={editedData.profileImage || characterImage}
           alt="프로필 이미지"
           onClick={() => {
             if (isOwner && isEditMode) {
@@ -590,13 +570,12 @@ console.log("[ProfileCard] imgSrc(final):", imgSrc);
               }));
               
             }
-              e.currentTarget.value = ""; //두번째 클릭 이슈 방지
           }}
         />
 
         {/* 이미지 리셋 버튼 추가*/}
 
-        {/* {isOwner && isEditMode && onImageReset && (
+        {isOwner && isEditMode && onImageReset && (
           <div
             style={{
               marginTop: "0.5rem",
@@ -619,7 +598,7 @@ console.log("[ProfileCard] imgSrc(final):", imgSrc);
              기본 이미지로 되돌리기
             </button>
           </div>
-        )} */}
+        )}
 
 
       <UserInfo>

--- a/src/components/StudyCard.tsx
+++ b/src/components/StudyCard.tsx
@@ -25,6 +25,18 @@ const countryCharacterImages: { [key: string]: string } = {
   CN: ChinaProfileImg,
 };
 
+const BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+
+const toAbsoluteUrl = (url: string) => {
+  if (!url) return url;
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+
+  const normalizedBase = BASE_URL.endsWith("/") ? BASE_URL.slice(0, -1) : BASE_URL;
+  const normalizedPath = url.startsWith("/") ? url : `/${url}`;
+  return `${normalizedBase}${normalizedPath}`;
+};
+
+
 const CardContainer = styled.div`
   background-color: var(--white);
   border: 1px solid var(--gray);
@@ -122,6 +134,10 @@ const MoreButton = styled.span`
 
 const StudyCard = ({ study, onClick, currentUserId, authorCountry }: StudyCardProps) => {
 
+  console.log("[StudyCard] authorProfileImageUrl:", study.authorProfileImageUrl);
+  console.log("[StudyCard] authorCountry:", authorCountry);
+
+
   const useDefaultProfile =
     typeof window !== "undefined" &&
     localStorage.getItem("useDefaultProfileImage") === "true";
@@ -146,8 +162,11 @@ const StudyCard = ({ study, onClick, currentUserId, authorCountry }: StudyCardPr
   }
 
   const finalSrc = characterImage
-    ? characterImage.replace(/([^:]\/)\/+/g, "$1")
+    ? toAbsoluteUrl(characterImage).replace(/([^:]\/)\/+/g, "$1")
     : fallbackCharacter;
+
+  console.log("[StudyCard] finalSrc:", finalSrc);
+
   
   // 캠퍼스 
   const campusMap: { [key: string]: string } = {
@@ -182,7 +201,14 @@ const primaryLanguage = study.languages?.[0];
   return (
     <CardContainer onClick={onClick}>
       <ProfileSection>
-        <ProfileImage src={finalSrc} alt={study.authorNickname || "작성자"} />
+        <ProfileImage 
+        src={finalSrc} 
+        alt={study.authorNickname || "작성자"} 
+        onError={(e) => {
+          e.currentTarget.src = fallbackCharacter;
+  }}
+/>
+
       </ProfileSection>
       
       <ContentSection>

--- a/src/pages/study/StudyList.tsx
+++ b/src/pages/study/StudyList.tsx
@@ -274,6 +274,8 @@ const StudyList = () => {
           try {
             const res = await axiosInstance.get(`/api/profiles/${study.authorId}`);
 
+            console.log("[StudyList] author profile res:", res.data);
+
             return {
               ...study,
               authorCountry: res.data.country, 


### PR DESCRIPTION
## 📌 PR 개요
- 마이페이지 & 프로필 이미지 이슈 해결 정리

## 🔗 관련 이슈
- close #165 
1. 기본 국적 이미지 로직 정상화 : 
- /api/users/me 응답에서 country가 null로 내려오는 경우 발생
- 이로 인해 한국인 계정인데도 기본 국적 이미지가 안 뜨는 문제 발생

2. 프로필 이미지 업로드 403 forbidden 문제 해결
- POST /api/users/me/profile-image 요청 시 403 Forbidden
- 콘솔 확인 결과: Content-Type: application/json으로 전송되고 있었음 / 서버 스키마는 multipart/form-data (file) 요구

3. profileImageURL 상대경로 문제 해결(스터디 리스트 오른쪽 게시글 이미지 오류 - studyCard)

4. (이전 이슈)이미지 재업로드 두 번 클릭해야 되는 문제 해결

5. (이전 이슈) 기본 이미지로 되돌리기 기능 정리

6. 스터디 카드 이미지 안 뜨던 문제 해결(studyCard)

## 🛠 변경 내용
1. 기본 국적 이미지 로직 정상화:
- [해결] country 정규화 처리 : trim().toUpperCase();
- [해결] 매핑 실패 시 무조건 KR로 fallback

2. 프로필 이미지 업로드 403 forbidden 문제 해결:
- [문제] FormData로 보내는 업로드 요청인데 network에서 Content-Type이 application/json으로 확인됨 => multipart로 안나가고 있음(백 : 파일이 아닌 json 요청이 들어왔다고 인식가능 -> 서버에서 이를 막음)
- [문제] 백엔드 api 명세서에 작성되어있는 /api/users/me/profile-image의 스키마에는 file(binary)로 되어있으므로 multipart여야 함
- [원인] axiosInstance에 전역으로 Content-Type: application/json 고정됨
- [원인] 파일 업로드 요청에서도 이 헤더가 덮여서 서버에서 차단됨
- [해결] axios가 FormData일 때 자동으로 Content-Type 설정하도록 수정 => 즉, FormData일 때 axiosInstance의 고정 Content-Type 제거, 그 외는 기존과 동일하게 json 형태로 출력
- [결과] 프로필 이미지 업로드 정상 작동 & 403 오류 해결(서버에서 정상적으로 받음) & axios 설정 이슈였음

3. profileImageURL 상대경로 문제 해결
- [문제] 서버에서 내려오는 값이 "profileImageUrl" : "uploads/profile/xxx.svg"형태였음. 그래서 <img src>에 그대로 넣으면 이미지 403, 깨짐 -> 그래서 스터디 리스트에 아예 국적, 업로드 이미지가 보이지 않았음(정확히는 component - studyCard)
- [해결] axios interceptor : 응답에서 profileImageURL이 상대경로면 base_url 붙여서 '절대경로'로 변환시킴
- [결과] studyCard 이미지에 업로드 이미지 정상 표시됨

4. (이전 이슈) 이미지 재업로드 두 번 클릭해야 하는 문제 해결
- [문제] 같은 파일 재선택 시 onchange가 안 불림
- [해결] e.currentTarget.vlue = ""; 로 설정
- [결과] 같은 이미지 재업로드도 즉시 인식

5. 기본 이미지로 되돌리기 기능 정리
- [문제] 프론트에서 profileImageUrl = null로 덮었지만 서버에는 이전 업로드 이미지가 남아 있음 & 로그아웃 → 로그인 시 다시 업로드 이미지로 돌아감 
- [판단] 서버에 DELETE /profile-image API 필요
- [조치] 프론트 임시 null 처리 코드 제거 & 업로드 POST와 대응되는 DELETE API가 필요

6. 스터디 카드 이미지 안 뜨던 문제 해결(studyCard)
- [문제] authorProfileImageUrl = "uploads/profile/xxx.png"로 그대로 <img src>에 넣어서 이미지 깨짐
- [해결] 절대경로 변환 함수 사용 : const finalSrc 수정 ; toAbsoluteUrl(characterImage) 
- [해결] 안정성 보강 - fallbackCharacter

## 🧪 확인 사항
- [x] 로컬에서 정상 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능 정상 동작 유지
- [x] 불필요한 API 호출 없음

## 📝 비고
- delete api 연결 예정
