### PR TITLE
feature: 내 프로필 클릭 시 마이페이지로 이동 처리

### DIFF
--- a/src/pages/profile/ProfileList.tsx
+++ b/src/pages/profile/ProfileList.tsx
@@ -213,12 +213,14 @@ const ProfileList: React.FC = () => {
     topicKeyword: "",
   });
 
-  const currentUserId = Number(localStorage.getItem("userId"));
+  const currentUserIdRaw = localStorage.getItem("userId");
+  const currentUserId = currentUserIdRaw ? Number(currentUserIdRaw) : null;
+  
   const useDefaultProfile =
     localStorage.getItem("useDefaultProfileImage") === "true";
 
 
-  // 프로필 조회 (필터 적용)
+  // 프로필 조회 (필터 적용)l  
   const fetchProfiles = async (page = 0) => {
     try {
       const params: any = { page, size: profilesPerPage };
@@ -251,6 +253,10 @@ const ProfileList: React.FC = () => {
   };
 
   const handleProfileClick = (userId: number) => {
+    if (currentUserId !== null && userId === currentUserId) {
+      navigate("/mypage");
+      return;
+    }
     navigate(`/profile/${userId}`);
   };
 


### PR DESCRIPTION
## 📌 PR 개요
- 프로필 리스트에 뜨는 profileBanner 컴포넌트 중 자신의 프로필 클릭 시 마이페이지로 이동

## 🔗 관련 이슈
- close #167 

## 🛠 변경 내용
- 프로필 카드 클릭 시 userId와 현재 로그인 사용자 ID를 비교하여 분기 처리(currentUserId vs userId)
- 내 프로필 클릭 시 → 절대 경로(/mypage)로 이동
- 타인 프로필 클릭 시 → 기존처럼 /profile/:userId로 이동
`const handleProfileClick = (userId: number) => {
  if (currentUserId !== null && userId === currentUserId) {
    navigate("/mypage");
    return;
  }
  navigate(`/profile/${userId}`);
};
`
- 상대 경로 사용을 제거하여 잘못된 URL 결합 방지
- currentUserId를 localStorage에 파싱하여 null 케이스 방 
전 : `const currentUserId = Number(localStorage.getItem("userId"));
`
후 : `const currentUserIdRaw = localStorage.getItem("userId");
const currentUserId = currentUserIdRaw ? Number(currentUserIdRaw) : null;
`

## 🧪 확인 사항
- [x] 로컬에서 정상 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능 정상 동작 유지
- [x] 불필요한 API 호출 없음

## 📝 비고
- 기존 방식이 나을 시 롤백
