### PR TITLE
feature: 타인 profileCard 컴포넌트 내부 키워드 노출

### DIFF
--- a/src/pages/profile/ProfileDetail.tsx
+++ b/src/pages/profile/ProfileDetail.tsx
@@ -143,7 +143,7 @@ const ProfileDetail = () => {
           profileImageUrl: profileImageUrl, 
           introTitle: data.infoTitle,
           introContent: data.infoContent,
-          keywords: data.keywords.map((k: any) => k.name),
+          keywords: data.keywords,
           languages: {
             native: data.nativeLanguages.map((l: any) => LANGUAGE_MAP[l.code] || l.name),
             learn: data.learnLanguages.map((l: any) => LANGUAGE_MAP[l.code] || l.name),

--- a/src/types/mypage&profile.types.ts
+++ b/src/types/mypage&profile.types.ts
@@ -28,9 +28,13 @@ export interface LanguageItem {
   type: 'NATIVE' | 'LEARN';
 }
 
+export type KeywordCategory = "PERSONALITY" | "HOBBY" | "TOPIC";
+
 export interface KeywordItem {
   id: number;
   name: string;
+  category: KeywordCategory;
+
 }
 
 // 언어 조회/수정 타입
@@ -83,7 +87,7 @@ export interface Post {
 // ------메타데이터 타입 
 
 // 키워드 그룹 조회
-export interface KeywordItem {
+export interface KeywordMetaItem {
   id: number;
   name: string;
   active: boolean;
@@ -91,13 +95,13 @@ export interface KeywordItem {
 }
 
 export interface GroupedKeywordsResponse {
-  personality: KeywordItem[];
-  hobby: KeywordItem[];
-  topic: KeywordItem[];
+  personality: KeywordMetaItem[];
+  hobby: KeywordMetaItem[];
+  topic: KeywordMetaItem[];
 }
 
 // 언어 목록
-export interface LanguageItem {
+export interface LanguageMetaItem {
   code: string;
   name: string;
 }


### PR DESCRIPTION
## 📌 PR 개요
- 프로필 상세페이지(타인) 상단 컴포넌트  내부에 키워드 칩 나오게끔 수정
- 키워드 칩을 카테고리별(Personality / Hobby / Topic)로 색상 분리
- 키워드 칩 스타일 조정

## 🔗 관련 이슈
- close #168  

## 🛠 변경 내용
- `ProfileCard` 컴포넌트
-- isOwner가 false인 경우(= 타인 프로필, currentUserId와 다른 Id) 키워드 칩 정상 노출되도록 처리
-- 키워드 데이터를 category 기준으로 정규화하여 렌더링하도록 구조 정리
-- 키워드 칩 색상 스타일 분기 처리 (PERSONALITY / HOBBY / TOPIC)
- 프로필 상세페이지(`/api/profiles/{id}`) 연동 시 키워드 칩 정상 노출 확인
- `/api/users/me`, `/api/users/me/keywords`로 keywords 받아서 isOwner가 true일 때도 키워드 노출되도록 수정하였으나 해당 API에서 키워드가 빈 배열로 내려오는 이슈 확인 _*현재 백엔드 팀원과 원인 확인 및 수정 진행 중에 있습니다._

## 🧪 확인 사항
- [x] 로컬에서 정상 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능 정상 동작 유지
- [x] 불필요한 API 호출 없음

## 📝 비고
- 마이페이지(currentUserId) 상단 키워드 칩 노출도 함께 작업 중이었으나, 현재 사용 중인` /api/users/me`, `/api/users/me/keywords `API에서 personality / hobby / topic 키워드가 빈 배열로 응답되는 문제를 확인하였습니다. 
-- 동일 유저임에도 프로필 상세(`/api/profiles/{id}`)에서는 키워드가 정상적으로 내려오는 점을 고려할 때 마이페이지용 키워드 조회 API 정합성 이슈로 판단되어 관련 코드 리뷰 및 백엔드 팀원분께 공유한 상태입니다.