### PR TITLE
feat:회원가입 키워드 선택 3-5개로 제한

### DIFF
--- a/src/pages/signup/SignUp4.tsx
+++ b/src/pages/signup/SignUp4.tsx
@@ -89,6 +89,17 @@ const Option = styled.div`
 const KeywordContainer = styled.div`
   display: flex;
   flex-direction: column;
+  gap: 1rem;
+`
+
+const ErrorMessage = styled.div`
+  color: #ff4444;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  background-color: #fff5f5;
+  border-radius: 0.5rem;
+  border: 1px solid #ffcccc;
 `
 
 const KeywordBox = styled.div`
@@ -133,8 +144,21 @@ const SignUp4 = () => {
     if (current.includes(keyword)) {
       setState(current.filter((item) => item !== keyword));
     } else {
+      // 5개 초과 선택 방지
+      if (current.length >= 5) {
+        alert("키워드는 3-5개 선택해주세요.");
+        return;
+      }
       setState([...current, keyword]);
     }
+  };
+
+  const validateKeywords = (keywords: string[], keywordType: string): boolean => {
+    if (keywords.length < 3 || keywords.length > 5) {
+      alert("키워드는 3-5개 선택해주세요.");
+      return false;
+    }
+    return true;
   };
 
   const handleSubmit = async () => {
@@ -142,6 +166,17 @@ const SignUp4 = () => {
     
     if (!onboardingToken) {
       alert("인증 토큰이 없습니다. 이전 단계를 다시 진행해주세요.");
+      return;
+    }
+
+    // 키워드 유효성 검증 (각 키워드 타입별로 3-5개 범위 확인)
+    if (!validateKeywords(selectedPersonality, "성격")) {
+      return;
+    }
+    if (!validateKeywords(selectedHobby, "취미")) {
+      return;
+    }
+    if (!validateKeywords(selectedSubject, "주제")) {
       return;
     }
 
@@ -220,7 +255,7 @@ const SignUp4 = () => {
               </SelectedBox>
             </MbtiInputContainer>
             <KeywordContainer>
-            <p style={{ fontSize: "1.25rem" }}>자신의 성격에 맞는 키워드를 선택해주세요</p>
+            <p style={{ fontSize: "1.25rem" }}>자신의 성격에 맞는 키워드를 선택해주세요 <span style={{ fontSize: "1rem", color: "#9CA3AF" }}>(3-5개 선택)</span></p>
             <KeywordBox>
               {personality.map((persona) => (
                 <KeywordItem
@@ -237,7 +272,7 @@ const SignUp4 = () => {
               ))}
             </KeywordBox>
 
-            <p style={{ fontSize: "1.25rem" }}>관심있는 취미를 선택해주세요</p>
+            <p style={{ fontSize: "1.25rem" }}>관심있는 취미를 선택해주세요 <span style={{ fontSize: "1rem", color: "#9CA3AF" }}>(3-5개 선택)</span></p>
             <KeywordBox>
               {hobbis.map((hobby) => (
                 <KeywordItem
@@ -254,7 +289,7 @@ const SignUp4 = () => {
               ))}
             </KeywordBox>
 
-            <p style={{ fontSize: "1.25rem" }}>관심있는 주제를 선택해주세요</p>
+            <p style={{ fontSize: "1.25rem" }}>관심있는 주제를 선택해주세요 <span style={{ fontSize: "1rem", color: "#9CA3AF" }}>(3-5개 선택)</span></p>
             <KeywordBox>
               {subjects.map((subject) => (
                 <KeywordItem


### PR DESCRIPTION
## 이 PR에서 수행한 작업 요약

회원가입 Step4에서 키워드 선택 시 3-5개 범위 내에서만 선택 가능하도록 프론트엔드 유효성 검증을 추가했습니다. 사용자가 3개 미만 또는 5개 초과로 선택한 경우 alert를 통해 안내하고, 유효성 검증을 통과한 경우에만 API 요청을 수행하도록 개선했습니다.

## 🔗 관련 이슈
closes #176 

## 🛠 변경 내용

### 주요 변경 사항
- 키워드 선택 개수 유효성 검증 로직 추가 (3-5개 범위)
- 5개 초과 선택 시 실시간 방지 기능 추가
- 회원가입 완료 버튼 클릭 시 키워드 유효성 검증 수행
- 유효성 검증 통과 시에만 step4 API 요청 수행
- alert를 통한 에러 메시지 표시

### 수정/추가된 컴포넌트 또는 로직

**`FE/src/pages/signup/SignUp4.tsx`**
- `toggleKeyword` 함수: 5개 초과 선택 시 alert 표시 및 선택 방지 로직 추가
- `validateKeywords` 함수: 키워드 개수 유효성 검증 함수 추가 (3-5개 범위 확인)
- `handleSubmit` 함수: API 요청 전 각 키워드 타입별 유효성 검증 로직 추가
  - 성격 키워드 (personalityKeywords)
  - 취미 키워드 (hobbyKeywords)
  - 주제 키워드 (topicKeywords)
- UI 안내 문구: 각 키워드 선택 섹션에 "(3-5개 선택)" 안내 문구 추가

## 🧪 확인 사항

- ✅ 로컬에서 정상 동작 확인
  - 키워드 3개 미만 선택 후 회원가입 완료 버튼 클릭 시 alert 표시 및 API 요청 차단 확인
  - 키워드 5개 초과 선택 시도 시 alert 표시 및 선택 방지 확인
  - 키워드 3-5개 범위 내 선택 후 회원가입 완료 버튼 클릭 시 정상적으로 API 요청 수행 확인
- ✅ 타입 에러 없음
- ✅ 기존 기능 정상 동작 유지
  - MBTI 선택 기능 정상 동작
  - 키워드 선택/해제 기능 정상 동작
  - 회원가입 완료 플로우 정상 동작
- ✅ 불필요한 API 호출 없음
  - 유효성 검증 실패 시 API 요청 차단 확인

## 📝 비고
- 백엔드에서도 동일한 유효성 검증을 수행하고 있으나, 프론트엔드에서 사전에 방지하여 사용자 경험 개선 및 불필요한 API 요청 감소
