### PR TITLE
fix: me-comments api 다시 연결

### DIFF
--- a/src/components/ActivityTabs.tsx
+++ b/src/components/ActivityTabs.tsx
@@ -169,6 +169,13 @@ const CommentTag = styled.span`
 const OriginalPostTitle = styled.h4`
   margin: 0 0 1rem 0;
   color: var(--black);
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    color: var(--primary);
+    text-decoration: underline;
+  }
 `;
 
 const CommentContent = styled.p`
@@ -208,10 +215,12 @@ const CommentList = ({
   comments,
   onCommentEdit,
   onCommentDelete,
+  onPostClick,
 }: {
   comments: Comment[];
   onCommentEdit: (commentId: number, postId: number, content: string) => void;
   onCommentDelete: (commentId: number, postId: number) => void;
+  onPostClick: (postId: number) => void;
 }) => {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editingContent, setEditingContent] = useState<string>("");
@@ -244,7 +253,10 @@ const CommentList = ({
               </CommentTags>
             </CommentHeader>
             
-            <OriginalPostTitle className="H4">
+            <OriginalPostTitle 
+              className="H4"
+              onClick={() => onPostClick(comment.postId)}
+            >
               {comment.postTitle}
             </OriginalPostTitle>
             
@@ -385,6 +397,7 @@ const ActivityTabs = ({ activeTab,
         comments={comments}
     onCommentEdit={onCommentEdit}
     onCommentDelete={onCommentDelete}
+    onPostClick={onPostClick}
         />
       )}
     </Container>

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -127,47 +127,29 @@ const Mypage = () => {
 
     const fetchMyComments = async () => {
       try {
-        const res = await axiosInstance.get("/api/users/me/comments");
-        const data = res.data as any[];
+        const res = await axiosInstance.get("/api/users/me/study-comments");
+        // API 응답 구조: { success: true, message: "Success", data: [...] }
+        const data = res.data.data || res.data || [];
 
-        const mapped: Comment[] = await Promise.all(
-          data.map(async (comment) => {
-            try {
-              const postRes = await axiosInstance.get(
-                `/api/studies/${comment.postId}`
-              );
-              const post = postRes.data.data;
+        const mapped: Comment[] = data.map((comment: any) => {
+          const study = comment.study || {};
+          
+          const tags = [
+            ...(study.campuses || []),
+            ...(study.languages || []),
+          ];
 
-              const tags = [
-                ...(post.campuses || []),
-                ...(post.languages || []),
-              ];
-
-              return {
-                id: comment.id,
-                postId: comment.postId,
-                postTitle: post.title,
-                content: comment.content,
-                status: post.status as "모집중" | "마감",
-                currentParticipants: post.currentParticipants,
-                maxParticipants: post.capacity,
-                tags,
-              } as Comment;
-            } catch (e) {
-              console.error(
-                `댓글 ${comment.id}의 게시글 정보 조회 실패:`,
-                e
-              );
-
-              return {
-                id: comment.id,
-                postId: comment.postId,
-                postTitle: "(게시글 정보를 가져오지 못했습니다)",
-                content: comment.content,
-              } as Comment;
-            }
-          })
-        );
+          return {
+            id: comment.commentId,
+            postId: study.postId,
+            postTitle: study.title || "(제목 없음)",
+            content: comment.content,
+            status: study.status as "모집중" | "마감",
+            currentParticipants: study.currentParticipants || 0,
+            maxParticipants: study.capacity || 0,
+            tags,
+          } as Comment;
+        });
 
         setMyComments(mapped);
       } catch (error) {


### PR DESCRIPTION
## 📌 PR 개요
api/users/me/comments 내가 단 댓글 조회하는 부분 요청 url을 api/users/me/study-comments 이걸로 바꿈

## 🔗 관련 이슈
- close #이슈번호 (없으면 생략)

## 🛠 변경 내용
- 댓글 작성자(본인)의 **국적 누락**
- 댓글이 속한 **스터디 게시글 요약 정보 전반 누락**
    - 제목, 모집 상태, 인원 수, 캠퍼스, 언어
    - 게시글 작성자 프로필 이미지 / 국적
- 현재 프론트측에서 `postId` 로 해당 게시글 조회하는 api 불러와 api 2번 호출 이루어짐
위 사항 해결됨

