### PR TITLE
feature: 탈퇴 api 연결 및 EG매핑키 수정, profileCard width 조정

### DIFF
--- a/src/components/ProfileBanner.tsx
+++ b/src/components/ProfileBanner.tsx
@@ -40,7 +40,7 @@ const countryCharacterImages: { [key: CountryCode]: string } = {
   US: AmericaProfileImg,
   KR: KoreaProfileImg,
   IT: ItalyProfileImg,
-  AR: EgyptProfileImg,
+  EG: EgyptProfileImg,
   CN: ChinaProfileImg,
 };
 

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -47,7 +47,7 @@ const countryCharacterImages: { [key: string]: string } = {
   US: AmericaProfileImg,
   KR: KoreaProfileImg,
   IT: ItalyProfileImg,
-  AR: EgyptProfileImg,
+  EG: EgyptProfileImg,
   CN: ChinaProfileImg,
 };
 
@@ -67,6 +67,7 @@ const languageOptions = [
 
 const Card = styled.div<{ $isEditMode: boolean }>`
   width: 100%;
+  box-sizing: border-box;
   background-color: var(--white);
   border: 1px solid var(--gray);
   border-radius: 1rem;
@@ -82,6 +83,7 @@ const TopSection = styled.div`
   display: flex;
   gap: 3rem;
   margin-bottom: 3rem;
+  min-width: 0;
 `;
 
 const LeftSection = styled.div`
@@ -116,6 +118,7 @@ const UserMbti = styled.div`
 
 const RightSection = styled.div`
   flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -260,7 +263,7 @@ const CancelButton = styled.button`
 
 const ContactGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1.5rem;
 `;
 

--- a/src/components/StudyCard.tsx
+++ b/src/components/StudyCard.tsx
@@ -18,9 +18,7 @@ const countryCharacterImages: { [key: string]: string } = {
   US: AmericaProfileImg,
   KR: KoreaProfileImg,
   IT: ItalyProfileImg,
-  AR: EgyptProfileImg,
   EG: EgyptProfileImg,
-
   CN: ChinaProfileImg,
 };
 

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -20,6 +20,30 @@ const ContentWrapper = styled.div`
   padding: 0 2rem;
 `;
 
+const WithdrawButtonRow = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;`;
+
+const WithdrawButton = styled.button`
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  border: 1px solid var(--gray-wf);
+  background-color: var(--white);
+  color: var(--gray-700);
+  cursor: pointer;
+  
+  &:hover {
+    background-color: var(--gray-400);
+    background: var(--gray-text-filled);
+  }
+
+  &:active {
+  transform: translateY(1px);
+}
+`;
+
 const PageTitle = styled.h1`
   margin-bottom: 2.5rem;
 `;
@@ -393,6 +417,30 @@ const Mypage = () => {
     }
   };
 
+  //탈퇴
+  const handleWithdraw = async () => {
+  const ok = window.confirm(
+    "정말 회원탈퇴 하시겠습니까?\n탈퇴 후에는 계정을 복구할 수 없어요."
+  );
+  if (!ok) return;
+
+  try {
+    await axiosInstance.delete("/api/users/me");
+
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken"); 
+    localStorage.removeItem("userId");
+
+    alert("회원탈퇴가 완료되었습니다.");
+
+    navigate("/signup/step1");
+  } catch (error) {
+    console.error("회원탈퇴 실패:", error);
+    alert("회원탈퇴 중 오류가 발생했습니다.");
+  }
+};
+
+
   return (
     <Container>
       <ContentWrapper>
@@ -405,6 +453,7 @@ const Mypage = () => {
             : null;
         
           return (
+            <>
             <ProfileCard
               key={`${cleanedProfileUrl}-${userData._updateKey || ""}`}
               userId={userData.id}
@@ -437,6 +486,12 @@ const Mypage = () => {
               onImageUpload={handleProfileImageUpload}
               // onImageReset={handleProfileImageReset} 
             />
+              <WithdrawButtonRow>
+                <WithdrawButton onClick={handleWithdraw} className="Button1">
+                  회원탈퇴
+                </WithdrawButton>
+              </WithdrawButtonRow>
+            </>
           );
         })()
       )}

--- a/src/pages/profile/ProfileDetail.tsx
+++ b/src/pages/profile/ProfileDetail.tsx
@@ -122,7 +122,7 @@ const ProfileDetail = () => {
           US: AmericaProfileImg,
           KR: KoreaProfileImg,
           IT: ItalyProfileImg,
-          AR: EgyptProfileImg,
+          EG: EgyptProfileImg,
           CN: ChinaProfileImg,
         };
   

--- a/src/pages/study/StudyDetail.tsx
+++ b/src/pages/study/StudyDetail.tsx
@@ -40,7 +40,7 @@ const countryCharacterImages: { [key: string]: string } = {
     US: AmericaProfileImg,
     KR: KoreaProfileImg,
     IT: ItalyProfileImg,
-    AR: EgyptProfileImg,
+    EG: EgyptProfileImg,
     CN: ChinaProfileImg,
 };
 

--- a/src/pages/study/StudyList.tsx
+++ b/src/pages/study/StudyList.tsx
@@ -18,7 +18,6 @@ const countryCharacterImages: { [key: string]: string } = {
   US: AmericaProfileImg,
   KR: KoreaProfileImg,
   IT: ItalyProfileImg,
-  AR: EgyptProfileImg,
   EG: EgyptProfileImg,
   CN: ChinaProfileImg,
 };

--- a/src/pages/study/StudyPost.tsx
+++ b/src/pages/study/StudyPost.tsx
@@ -16,7 +16,7 @@ const countryCharacterImages: { [key: string]: string } = {
   US: AmericaProfileImg,
   KR: KoreaProfileImg,
   IT: ItalyProfileImg,
-  AR: EgyptProfileImg,
+  EG: EgyptProfileImg,
   CN: ChinaProfileImg,
 };
 


### PR DESCRIPTION
## 📌 PR 개요
- 마이페이지 회원탈퇴(내 계정 삭제) API 연동 및 탈퇴 후 로컬 스토리지 정리/리다이렉트 처리
- ProfileCard 레이아웃이 ContentWrapper(최대 1200px) 범위를 넘어가던 이슈 수정(폭/레이아웃 안정화)
- 마이페이지에서 EG(이집트) 기본 캐릭터 이미지가 안 뜨던 매핑 키 오류 수정(AR → EG)

## 🔗 관련 이슈
- close #172 (currentUser의 profileCard 키워드 노출)
- close #174 

## 🛠 변경 내용

### 1. 회원탈퇴 API 연결
- `/api/users/me` DELETE API 연동
- 회원탈퇴 확인(confirm) 후 요청 처리
- 탈퇴 성공 시 로컬 스토리지 정리 후 회원가입 페이지로 이동

**로컬 스토리지 처리**
- `accessToken` 삭제
- `refreshToken` 삭제
- `userId` 삭제

**UI**
- 회원탈퇴 버튼을 ProfileCard 하단에 배치
- ProfileCard 기준 우측 정렬로 배치 (viewport fixed 방식 사용하지 않음)

#### [문제]
- 탈퇴 버튼을 `position: fixed`로 둘 경우 화면 크기에 따라 카드 기준 정렬이 깨짐
#### [원인]
- fixed는 viewport 기준이라 ContentWrapper / ProfileCard 레이아웃과 무관하게 동작함
#### [해결]
- ProfileCard 하단에 버튼 영역을 두고  
  `display: flex; justify-content: flex-end; width: 100%` 방식으로 카드 기준 정렬 처리

---

### 2. ProfileCard width 오버플로우 수정
- ProfileCard가 ContentWrapper(max-width: 1200px)를 초과하던 레이아웃 이슈 해결

**수정 내용**
- `Card`에 `box-sizing: border-box` 적용
- flex 자식 요소(`TopSection`, `RightSection`)에 `min-width: 0` 추가
- Grid 레이아웃에 `grid-template-columns: repeat(4, minmax(0, 1fr))` 적용

#### [문제]
- ProfileCard 내부 요소가 줄어들지 않고 오른쪽으로 오버플로우 발생
#### [원인]
- flex/grid 기본 `min-width: auto` 특성으로 인해 내부 콘텐츠가 컨테이너를 밀어냄
#### [해결]
- `min-width: 0` + `minmax(0, 1fr)` 적용으로 컨테이너 폭 내에서 정상 수축되도록 수정

---

### 3. 마이페이지 EG 프로필 이미지 미노출 수정
- 이집트(EG) 유저의 기본 프로필 이미지가 표시되지 않던 문제 수정

**수정 내용**
- 국가별 캐릭터 이미지 매핑 키 수정  
  `AR → EG`

#### [문제]
- API 응답에서 `country: "EG"` 인데 기본 캐릭터 이미지가 표시되지 않음
#### [원인]
- 프론트 이미지 매핑 객체에서 이집트 키가 `AR`로 잘못 정의되어 있음
#### [해결]
- 모든 countryCharacterImages의 매핑 키를 API 국가 코드와 동일하게 `EG`로 수정, AR과 EG 동시에 있을 시 AR 삭제

## 🧪 확인 사항
- [x] 로컬에서 정상 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능 정상 동작 유지
- [x] 불필요한 API 호출 없음

## 📝 비고
- 프로필 이미지 삭제 api 연결 예정입니다.
