### PR TITLE
feature: 프로필이미지삭제 api 연결 및 버튼 재구현

### DIFF
--- a/src/components/ProfileBanner.tsx
+++ b/src/components/ProfileBanner.tsx
@@ -49,7 +49,7 @@ const bannerWrapper: { [key: CountryCode]: string } = {
   US: AmericaBannerImg,
   KR: KoreaBannerImg,
   IT: ItalyBannerImg,
-  AR: EgyptBannerImg,
+  EG: EgyptBannerImg,
   CN: ChinaBannerImg,
 };
 

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -28,7 +28,7 @@ const WithdrawButtonRow = styled.div`
 
 const WithdrawButton = styled.button`
   padding: 0.75rem 1.5rem;
-  border-radius: 8px;
+  border-radius: 0.75rem;
   border: 1px solid var(--gray-wf);
   background-color: var(--white);
   color: var(--gray-700);
@@ -318,62 +318,38 @@ const Mypage = () => {
       alert("이미지 업로드 중 오류가 발생했습니다.");
     }
   };
-  // 이미지 리셋 핸들러 추가(이미지 삭제 할 수 있도록)
-  //  const handleProfileImageReset = async () => {
-  //   if (!userData) return;
 
-  //   if (!window.confirm("업로드한 프로필 이미지를 삭제하고 기본 이미지로 되돌릴까요?")) {
-  //     return;
-  //   }
+  //이미지 리셋 헨들러(업로드한 이미지 -> 기본 국적 이미지로 변경)
+const handleProfileImageReset = async () => {
+  if (!userData) return;
 
-  //   try {
-  //     // 현재 state에 있는 값들 그대로 보내고, profileImageUrl만 null로 바꿔서 보낸다.
-  //     const finalData = {
-  //       name: userData.name,
-  //       nickname: userData.nickname,
-  //       mbti: userData.mbti,
-  //       profileImageUrl: null, // 이미지 제거
-  //       infoTitle: userData.infoTitle,
-  //       infoContent: userData.infoContent,
-  //       campus: userData.campus,
-  //       country: userData.country,
-  //       email: userData.email,
-  //       nativeLanguages: languages.nativeCodes,
-  //       learnLanguages: languages.learnCodes,
-  //       personalityKeywords: keywords.personality,
-  //       hobbyKeywords: keywords.hobby,
-  //       topicKeywords: keywords.topic,
-  //     };
+  const ok = window.confirm(
+    "업로드한 프로필 이미지를 삭제하고 기본 이미지로 되돌릴까요?"
+  );
+  if (!ok) return;
 
-  //     await axiosInstance.patch("/api/users/me", finalData);
+  try {
+    await axiosInstance.delete("/api/users/me/profile-image");
 
-  //     // 다시 내 정보 불러오기
-  //     const refreshed = await axiosInstance.get("/api/users/me");
-  //     const refreshedUser = refreshed.data;
+    localStorage.setItem("useDefaultProfileImage", "true");
 
-  //     localStorage.setItem("useDefaultProfileImage", "true");
+    const refreshed = await axiosInstance.get("/api/users/me");
+    const refreshedUser = refreshed.data;
 
-  //     refreshedUser.profileImageUrl = null; //강제로 되돌리기(백에서 null 안줘도 프론트에서 처리)
+    refreshedUser.profileImageUrl = null;
 
-  //     setUserData(refreshedUser);
-  //     setLanguages({
-  //       nativeCodes: refreshedUser.nativeLanguages || [],
-  //       learnCodes: refreshedUser.learnLanguages || [],
-  //     });
-  //     setKeywords({
-  //       personality: refreshedUser.personalityKeywords || [],
-  //       hobby: refreshedUser.hobbyKeywords || [],
-  //       topic: refreshedUser.topicKeywords || [],
-  //     });
+    setUserData({
+      ...refreshedUser,
+      _updateKey: Date.now(),
+    });
 
+    alert("프로필 이미지를 삭제하고 기본 이미지로 되돌렸습니다.");
+  } catch (error) {
+    console.error("프로필 이미지 삭제(리셋) 실패:", error);
+    alert("이미지 초기화 중 오류가 발생했습니다.");
+  }
+};
 
-
-  //     alert("프로필 이미지를 삭제하고 기본 이미지로 되돌렸습니다.");
-  //   } catch (error) {
-  //     console.error("프로필 이미지 기본이미지로 되돌리기 실패:", error);
-  //     alert("이미지 초기화 중 오류가 발생했습니다.");
-  //   }
-  // };
 
   const handlePostClick = (postId: number) => {
     navigate(`/study/${postId}`);
@@ -484,7 +460,7 @@ const Mypage = () => {
               onSave={handleProfileSave}
               onCancel={() => setIsEditMode(false)}
               onImageUpload={handleProfileImageUpload}
-              // onImageReset={handleProfileImageReset} 
+              onImageReset={handleProfileImageReset} 
             />
               <WithdrawButtonRow>
                 <WithdrawButton onClick={handleWithdraw} className="Button1">


### PR DESCRIPTION
## 📌 PR 개요
- 마이페이지 프로필 이미지 삭제(기본 이미지 리셋) API 연동
- 프로필 배너 영역 BannerWrapper 캠퍼스 기준을 AR → EG로 수정

## 🔗 관련 이슈
- close #175 

## 🛠 변경 내용
- DELETE `/api/users/me/profile-image` API 연동
  - 업로드된 프로필 이미지 삭제 후 기본 썸네일로 리셋
  - 로컬스토리지 플래그(`useDefaultProfileImage`)를 활용해 UI 상태 안정화(오류 시 삭제ㅠㅠ!!)
- 마이페이지 내 ‘기본 이미지로 되돌리기’ 버튼' 주석 해제 및 기능 연결
- 프로필 배너 영역 BannerWrapper 캠퍼스 기준 AR → EG 변경

## 🧪 확인 사항
- [x] 로컬에서 정상 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능 정상 동작 유지
- [x] 불필요한 API 호출 없음

## 📝 비고
- 프로필 이미지 업로드/삭제 이후 상태 동기화는  `GET /api/users/me` 재호출 방식으로 처리
- 추후 프로필 관련 API 로직 분리 리팩토링 가능
