### PR TITLE
fix: 프로필배너 키워드 로직 수정

### DIFF
--- a/src/components/ProfileBanner.tsx
+++ b/src/components/ProfileBanner.tsx
@@ -22,6 +22,13 @@ interface LanguagePair {
   learn: LanguageCode[];
 }
 
+type KeywordCategory = "PERSONALITY" | "HOBBY" | "TOPIC";
+
+type KeywordItem = {
+  id: number;
+  category: KeywordCategory;
+  name: string;
+};
 export interface ProfileBannerProps {
   userId: number;
   nickname: string;
@@ -30,7 +37,7 @@ export interface ProfileBannerProps {
   mbti: string | null;
   profileImageUrl: string | null; 
   languages: LanguagePair;
-  keywords: string[];
+  keywords: KeywordItem[];
   intro: string | null;
   onClick?: () => void;
 }
@@ -110,6 +117,8 @@ const TopKeywordChip = styled.span`
   color: var(--gray-700);
   white-space: nowrap;
 `;
+
+
 
 // 메인 콘텐츠 영역 (프로필 이미지 + 소개글)
 const MainContent = styled.div`
@@ -222,10 +231,6 @@ export const getCleanImageUrl = (url: string | null, fallback: string) => {
   return `${base}/${url.replace(/^\//, "")}?t=${Date.now()}`;
 };
 
-
-
-
-
 const ProfileBanner = ({ 
   profileImageUrl,
   country,
@@ -245,7 +250,11 @@ const ProfileBanner = ({
   ? getCleanImageUrl(profileImageUrl, "")
   : defaultCharacter;
 
+  const pickOne = (cat: "PERSONALITY" | "HOBBY" | "TOPIC") =>
+  keywords.find((k) => k.category === cat)?.name;
 
+const top3Keywords = [pickOne("PERSONALITY"), pickOne("HOBBY"), pickOne("TOPIC")]
+  .filter(Boolean) as string[];
 
 
 
@@ -284,10 +293,13 @@ const ProfileBanner = ({
     <CardWrapper $country={validCountry} onClick={onClick}>
       <ContentContainer>
         <TopKeywordTags>
-          {keywords.slice(0, 3).map((keyword, index) => (
-            <TopKeywordChip className="Button2" key={`keyword-${index}`}>#{keyword}</TopKeywordChip>
+          {top3Keywords.map((keyword, index) => (
+            <TopKeywordChip className="Button2" key={`keyword-${index}`}>
+              #{keyword}
+            </TopKeywordChip>
           ))}
         </TopKeywordTags>
+
 
         <MainContent>
           <LeftSection>

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -24,7 +24,7 @@ const WithdrawButtonRow = styled.div`
   width: 100%;
   display: flex;
   justify-content: flex-end;
-  margin-top: 12px;`;
+  margin-top: 64px;`;
 
 const WithdrawButton = styled.button`
   padding: 0.75rem 1.5rem;
@@ -429,7 +429,6 @@ const handleProfileImageReset = async () => {
             : null;
         
           return (
-            <>
             <ProfileCard
               key={`${cleanedProfileUrl}-${userData._updateKey || ""}`}
               userId={userData.id}
@@ -462,12 +461,6 @@ const handleProfileImageReset = async () => {
               onImageUpload={handleProfileImageUpload}
               onImageReset={handleProfileImageReset} 
             />
-              <WithdrawButtonRow>
-                <WithdrawButton onClick={handleWithdraw} className="Button1">
-                  회원탈퇴
-                </WithdrawButton>
-              </WithdrawButtonRow>
-            </>
           );
         })()
       )}
@@ -482,6 +475,12 @@ const handleProfileImageReset = async () => {
           onCommentEdit={handleCommentEdit}          
           onCommentDelete={handleCommentDelete}
         />
+
+        <WithdrawButtonRow>
+            <WithdrawButton onClick={handleWithdraw} className="Button1">
+              회원탈퇴
+            </WithdrawButton>
+        </WithdrawButtonRow>
       </ContentWrapper>
     </Container>
   );

--- a/src/pages/profile/ProfileList.tsx
+++ b/src/pages/profile/ProfileList.tsx
@@ -14,6 +14,13 @@ interface Language {
   name: string;
 }
 
+type KeywordCategory = "PERSONALITY" | "HOBBY" | "TOPIC";
+
+type KeywordItem = {
+  id: number;
+  category: KeywordCategory;
+  name: string;
+};
 export interface ProfileCardItem {
   userId: number;
   nickname: string;
@@ -23,7 +30,7 @@ export interface ProfileCardItem {
   profileImageUrl: string | null;
   nativeLanguages: Language[];
   learnLanguages: Language[];
-  keywords: { id: number; name: string }[];
+  keywords: KeywordItem[];
   infoTitle: string | null;
   infoContent: string | null;
 }
@@ -419,7 +426,7 @@ const ProfileList: React.FC = () => {
           native: profile.nativeLanguages.map((l) => l.code),
           learn: profile.learnLanguages.map((l) => l.code),
         }}
-        keywords={profile.keywords.map((k) => k.name)}
+        keywords={profile.keywords}
         intro={
           profile.infoTitle && profile.infoContent
             ? `${profile.infoTitle}\n${profile.infoContent}`


### PR DESCRIPTION
## 📌 PR 개요
- 프로필 리스트 카드 상단에 노출되는 키워드 로직 수정
- 기존 “키워드 배열 순서 기준 상위 3개 노출(slice)” 방식에서  
  → 키워드 카테고리(PERSONALITY / HOBBY / TOPIC)별 1개씩 노출되도록 개선

## 🔗 관련 이슈
- close #173  

## 🛠 변경 내용
- `/api/profiles` 응답에서 내려오는 키워드 구조(`{ id, category, name }[]`)에 맞게 타입 정의 수정
  - `ProfileCardItem.keywords` 및 `ProfileBannerProps.keywords` 타입에 `category` 필드 추가
- `ProfileBanner` 컴포넌트 내 키워드 노출 로직 변경
- 기존: 키워드 배열의 순서에 의존하여 상위 3개를 단순 노출
  - 백엔드 응답에서 키워드가 성격/취미/주제 순으로 섞여 내려올 경우,
    특정 카테고리(예: 성격 키워드)만 중복 노출되는 문제가 있었음  
- 변경: `category` 값을 기준으로  
    - PERSONALITY / HOBBY / TOPIC 각 카테고리에서 1개씩 선택하여 총 3개 노출
- `ProfileList` → `ProfileBanner`로 키워드 전달 시
  - 불필요한 `map((k) => k.name)` 제거
    - 기존: `ProfileList`에서 키워드를 단순 문자열 배열로 변환하여 전달 (`map((k) => k.name)`)
      - 키워드의 카테고리 정보가 소실되어 배너에서 카테고리 기반 로직 처리 불가
    - 변경: 키워드 객체(`{ id, category, name }`)를 그대로 `ProfileBanner`로 전달
      - 키워드 카테고리 정보를 유지하여 배너 컴포넌트에서 명확한 노출 기준 적용

  - API 응답 키워드 배열을 그대로 전달하도록 수정

## 🧪 확인 사항
- [x] 로컬에서 프로필 리스트 정상 렌더링 확인
- [x] 타입 에러 없음
- [x] 기존 프로필 조회 / 필터 기능 정상 동작 유지
- [x] 추가 API 호출 없이 기존 `/api/profiles` 응답만 사용

## 📝 비고
- 현재는 각 카테고리에서 첫 번째 키워드를 대표 키워드로 노출
- 추후 기획에 따라 “대표 키워드 지정” 또는 “노출 우선순위” 로직으로 확장 가능

