### PR TITLE
fix: 프로필 이미지 비율 수정

### DIFF
--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -84,6 +84,7 @@ const MessageNickname = styled.div`
 const CharacterImage = styled.img`
   width: 3rem;
   height: 3.497rem;
+  object-fit: cover;
 `
 const ChatContainer = styled.div`
   display: flex;
@@ -121,6 +122,7 @@ const ChatHeader = styled.div`
 const ChatProfileImg = styled.img`
   width: 5rem;
   height: 5.82838rem;
+  object-fit: cover;
 `
 
 const ChatNicname = styled.div`

--- a/src/pages/study/StudyDetail.tsx
+++ b/src/pages/study/StudyDetail.tsx
@@ -107,6 +107,7 @@ const ProfileImage = styled.img`
   width: 80px;
   height: 80px;
   border-radius: 50%;
+  object-fit: cover;
   background-color: var(--gray);
 `;
 

--- a/src/pages/study/StudyList.tsx
+++ b/src/pages/study/StudyList.tsx
@@ -75,6 +75,7 @@ const ProfileImage = styled.img`
   width: 80px;
   height: 80px;
   border-radius: 50%;
+  object-fit: cover;
   background-color: var(--gray);
 `;
 

--- a/src/pages/study/StudyPost.tsx
+++ b/src/pages/study/StudyPost.tsx
@@ -74,6 +74,7 @@ const ProfileImage = styled.img`
   width: 80px;
   height: 80px;
   border-radius: 50%;
+  object-fit: cover;
   background-color: var(--gray);
 `;
 


### PR DESCRIPTION
## 📌 PR 개요
- 프로필 이미지가 찌그러져 보이는 문제를 해결하기 위해 `object-fit: cover` CSS 속성을 추가
- 스터디 모집, 스터디 상세보기, 스터디 게시글 작성, 쪽지방 페이지의 모든 프로필 이미지에 적용

## 🔗 관련 이슈
- (없으면 생략)

## 🛠 변경 내용
- **스터디 모집 페이지** (`FE/src/pages/study/StudyList.tsx`)
  - 왼쪽 패널의 `ProfileImage` 컴포넌트에 `object-fit: cover` 추가

- **스터디 게시글 작성 페이지** (`FE/src/pages/study/StudyPost.tsx`)
  - 왼쪽 패널의 `ProfileImage` 컴포넌트에 `object-fit: cover` 추가

- **스터디 상세보기 페이지** (`FE/src/pages/study/StudyDetail.tsx`)
  - 왼쪽 패널의 `ProfileImage` 컴포넌트에 `object-fit: cover` 추가

- **쪽지방 페이지** (`FE/src/pages/Message.tsx`)
  - 쪽지 목록의 `CharacterImage` 컴포넌트에 `object-fit: cover` 추가
  - 채팅 헤더의 `ChatProfileImg` 컴포넌트에 `object-fit: cover` 추가


## 📝 비고
- 모든 프로필 이미지가 원형 또는 지정된 크기 내에서 비율을 유지하며 표시
- 기존 기능에 영향을 주지 않는 순수 CSS 스타일 수정
