### PR TITLE
fix: 회원가입 캠퍼스 누락값 수정

### DIFF
--- a/src/components/AutoTranslate.tsx
+++ b/src/components/AutoTranslate.tsx
@@ -1,0 +1,128 @@
+import { ReactNode, useEffect, useState, useMemo } from "react";
+import { useLanguage } from "../contexts/LanguageContext";
+
+interface AutoTranslateProps {
+  children: ReactNode;
+  skipTranslation?: boolean; // 번역을 건너뛸 요소 (예: 코드, 이메일 등)
+}
+
+/**
+ * 자동 번역 컴포넌트
+ * children의 모든 텍스트를 현재 언어에 맞게 자동으로 번역합니다.
+ */
+export const AutoTranslate = ({ children, skipTranslation = false }: AutoTranslateProps) => {
+  const { language, translateDynamic } = useLanguage();
+  const [translatedChildren, setTranslatedChildren] = useState<ReactNode>(children);
+
+  useEffect(() => {
+    if (skipTranslation || language === "ko") {
+      setTranslatedChildren(children);
+      return;
+    }
+
+    const translateNode = async (node: any): Promise<any> => {
+      if (typeof node === "string") {
+        // 문자열인 경우 번역
+        if (node.trim()) {
+          try {
+            return await translateDynamic(node);
+          } catch (error) {
+            console.error("자동 번역 실패:", error);
+            return node;
+          }
+        }
+        return node;
+      }
+
+      if (typeof node === "number") {
+        return node;
+      }
+
+      if (!node || typeof node !== "object") {
+        return node;
+      }
+
+      // React 요소인 경우
+      if (node.type) {
+        // props를 처리
+        const newProps: any = { ...node.props };
+
+        // children이 있으면 재귀적으로 번역
+        if (node.props.children) {
+          if (Array.isArray(node.props.children)) {
+            newProps.children = await Promise.all(
+              node.props.children.map((child: any) => translateNode(child))
+            );
+          } else {
+            newProps.children = await translateNode(node.props.children);
+          }
+        }
+
+        // placeholder, alt, title 등의 텍스트 속성도 번역
+        if (newProps.placeholder && typeof newProps.placeholder === "string") {
+          try {
+            newProps.placeholder = await translateDynamic(newProps.placeholder);
+          } catch (error) {
+            console.error("placeholder 번역 실패:", error);
+          }
+        }
+
+        if (newProps.alt && typeof newProps.alt === "string") {
+          try {
+            newProps.alt = await translateDynamic(newProps.alt);
+          } catch (error) {
+            console.error("alt 번역 실패:", error);
+          }
+        }
+
+        if (newProps.title && typeof newProps.title === "string") {
+          try {
+            newProps.title = await translateDynamic(newProps.title);
+          } catch (error) {
+            console.error("title 번역 실패:", error);
+          }
+        }
+
+        return {
+          ...node,
+          props: newProps,
+        };
+      }
+
+      // 배열인 경우
+      if (Array.isArray(node)) {
+        return Promise.all(node.map((item) => translateNode(item)));
+      }
+
+      return node;
+    };
+
+    translateNode(children).then(setTranslatedChildren);
+  }, [children, language, translateDynamic, skipTranslation]);
+
+  return <>{translatedChildren}</>;
+};
+
+/**
+ * 간단한 텍스트 자동 번역 훅
+ */
+export const useAutoTranslate = (text: string): string => {
+  const { language, translateDynamic } = useLanguage();
+  const [translated, setTranslated] = useState(text);
+
+  useEffect(() => {
+    if (language === "ko" || !text || !text.trim()) {
+      setTranslated(text);
+      return;
+    }
+
+    translateDynamic(text)
+      .then(setTranslated)
+      .catch((error) => {
+        console.error("자동 번역 실패:", error);
+        setTranslated(text);
+      });
+  }, [text, language, translateDynamic]);
+
+  return translated;
+};

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,240 @@
+import { createContext, useContext, useState, useEffect, ReactNode, useCallback } from "react";
+import { translateText } from "../api/translateAPI";
+import { translatePageText, revertPageTranslation } from "../utils/autoTranslatePage";
+
+export type Language = "ko" | "en";
+
+interface LanguageContextType {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: (key: string) => string;
+  translateDynamic: (text: string) => Promise<string>;
+  isTranslating: boolean;
+  translateAllPageText?: () => Promise<void>; // 페이지 전체 자동 번역
+}
+
+// 언어 코드를 API에서 사용하는 언어명으로 변환
+const getLanguageName = (lang: Language): string => {
+  return lang === "ko" ? "한국어" : "영어";
+};
+
+const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
+
+// 번역 데이터
+const translations: Record<Language, Record<string, string>> = {
+  ko: {
+    // Header
+    "header.home": "홈",
+    "header.randomMatch": "랜덤 매칭",
+    "header.study": "스터디 모집",
+    "header.profile": "프로필 조회",
+    "header.message": "쪽지",
+    "header.mypage": "MYPAGE",
+    "header.login": "로그인",
+    "header.logout": "로그아웃",
+    
+    // Common
+    "common.save": "저장",
+    "common.cancel": "취소",
+    "common.edit": "수정하기",
+    "common.delete": "삭제",
+    "common.confirm": "확인",
+    "common.close": "닫기",
+    
+    // Profile
+    "profile.introTitle": "자기소개 제목을 입력해주세요",
+    "profile.introContent": "자기소개 내용을 입력해주세요",
+    "profile.campus": "캠퍼스",
+    "profile.nativeLanguage": "사용언어",
+    "profile.learnLanguage": "선호언어",
+    "profile.email": "이메일",
+    "profile.emailPrivate": "이메일은 비밀이에요",
+    "profile.resetImage": "기본 이미지로 되돌리기",
+    
+    // Messages
+    "message.logoutSuccess": "로그아웃되었습니다.",
+    "message.logoutError": "로그아웃 처리 중 문제가 발생했습니다.",
+    "message.matchingError": "매칭 요청 중 오류가 발생했습니다.",
+    
+    // Main Page
+    "main.bannerTitle": "새로운 문화와 친구, 지금 우리 학교 안에서 시작해요",
+    "main.bannerContent": "학교 이메일 인증으로 안전하게, 취향·성격·관심사 기반으로 나와 잘 맞는 외국인 친구를 찾아드려요.",
+    "main.bannerContent2": "1:1 채팅으로 자연스럽게 언어를 배우고 문화를 나누며, 교내에서 시작되는 글로벌 네트워킹을 경험하세요.",
+    "main.serviceTitle": "주요 서비스 소개",
+    "main.randomMatchTitle": "친구 랜덤 매칭",
+    "main.randomMatchContent": "취향과 성격을 기반으로",
+    "main.randomMatchContent2": "교내 외국인 친구를 자동 매칭해 대화까지!",
+    "main.studyTitle": "스터디 모집",
+    "main.studyContent": "언어 교환부터 전공 스터디까지,",
+    "main.studyContent2": "관심 분야별 팀을 만들어보세요!",
+    "main.messageTitle": "쪽지",
+    "main.messageContent": "친구들의 프로필을 구경하고",
+    "main.messageContent2": "친해지고 싶은 친구에게 쪽지를 보내세요!",
+    "main.startButton": "시작하기",
+  },
+  en: {
+    // Header
+    "header.home": "Home",
+    "header.randomMatch": "Random Match",
+    "header.study": "Study Group",
+    "header.profile": "Profile",
+    "header.message": "Message",
+    "header.mypage": "MYPAGE",
+    "header.login": "Login",
+    "header.logout": "Logout",
+    
+    // Common
+    "common.save": "Save",
+    "common.cancel": "Cancel",
+    "common.edit": "Edit",
+    "common.delete": "Delete",
+    "common.confirm": "Confirm",
+    "common.close": "Close",
+    
+    // Profile
+    "profile.introTitle": "Please enter your introduction title",
+    "profile.introContent": "Please enter your introduction content",
+    "profile.campus": "Campus",
+    "profile.nativeLanguage": "Native Language",
+    "profile.learnLanguage": "Preferred Language",
+    "profile.email": "Email",
+    "profile.emailPrivate": "Email is private",
+    "profile.resetImage": "Reset to default image",
+    
+    // Messages
+    "message.logoutSuccess": "Logged out successfully.",
+    "message.logoutError": "An error occurred during logout.",
+    "message.matchingError": "An error occurred during matching request.",
+    
+    // Main Page
+    "main.bannerTitle": "New culture and friends, start now within our school",
+    "main.bannerContent": "Securely with school email verification, we find foreign friends who match you based on your tastes, personality, and interests.",
+    "main.bannerContent2": "Naturally learn languages and share cultures through 1:1 chat, and experience global networking starting within the campus.",
+    "main.serviceTitle": "Key Services",
+    "main.randomMatchTitle": "Friend Random Matching",
+    "main.randomMatchContent": "Automatically match with foreign friends",
+    "main.randomMatchContent2": "on campus based on your tastes and personality, all the way to conversation!",
+    "main.studyTitle": "Study Group",
+    "main.studyContent": "From language exchange to major studies,",
+    "main.studyContent2": "create teams by your interests!",
+    "main.messageTitle": "Message",
+    "main.messageContent": "Browse your friends' profiles",
+    "main.messageContent2": "and send messages to friends you want to get closer to!",
+    "main.startButton": "Get Started",
+  },
+};
+
+export const LanguageProvider = ({ children }: { children: ReactNode }) => {
+  // localStorage에서 언어 설정 불러오기 (기본값: 한국어)
+  const [language, setLanguageState] = useState<Language>(() => {
+    const saved = localStorage.getItem("language");
+    return (saved === "ko" || saved === "en") ? saved : "ko";
+  });
+
+  const [isTranslating, setIsTranslating] = useState(false);
+  
+  // 번역 캐시: 같은 텍스트를 여러 번 번역하지 않도록
+  const [translationCache, setTranslationCache] = useState<
+    Map<string, string>
+  >(new Map());
+
+  // 언어 변경 시 localStorage에 저장 및 캐시 초기화
+  useEffect(() => {
+    localStorage.setItem("language", language);
+    // 언어가 변경되면 캐시 초기화 (다른 언어로 번역해야 하므로)
+    setTranslationCache(new Map());
+    
+    // DOM 직접 조작은 레이아웃을 깨뜨릴 수 있으므로 비활성화
+    // 대신 React 컴포넌트 레벨에서 번역 키를 사용하도록 권장
+    // 필요시 수동으로 translateAllPageText() 호출 가능
+  }, [language]);
+
+  // 페이지 전체 자동 번역 함수
+  const translateAllPageText = useCallback(async () => {
+    if (language === "en") {
+      await translatePageText("영어");
+    } else {
+      revertPageTranslation();
+    }
+  }, [language]);
+
+  const setLanguage = (lang: Language) => {
+    setLanguageState(lang);
+  };
+
+  // 정적 번역 함수 (UI 텍스트용)
+  const t = (key: string): string => {
+    return translations[language][key] || key;
+  };
+
+  // 동적 번역 함수 (사용자 입력 내용용)
+  const translateDynamic = useCallback(
+    async (text: string): Promise<string> => {
+      // 빈 텍스트나 공백만 있는 경우 원본 반환
+      if (!text || !text.trim()) {
+        return text;
+      }
+
+      // 현재 언어가 한국어면 번역 불필요
+      if (language === "ko") {
+        return text;
+      }
+
+      // 캐시 확인
+      const cacheKey = `${language}:${text}`;
+      if (translationCache.has(cacheKey)) {
+        return translationCache.get(cacheKey)!;
+      }
+
+      // 이미 번역 중이면 원본 반환 (중복 요청 방지)
+      if (isTranslating) {
+        return text;
+      }
+
+      try {
+        setIsTranslating(true);
+        const targetLang = getLanguageName(language);
+        const response = await translateText({
+          text: text.trim(),
+          targetLang: targetLang,
+        });
+
+        const translated = response.translatedText || text;
+        
+        // 캐시에 저장
+        setTranslationCache((prev) => {
+          const newCache = new Map(prev);
+          newCache.set(cacheKey, translated);
+          return newCache;
+        });
+
+        return translated;
+      } catch (error) {
+        console.error("동적 번역 실패:", error);
+        // 번역 실패 시 원본 텍스트 반환
+        return text;
+      } finally {
+        setIsTranslating(false);
+      }
+    },
+    [language, translationCache, isTranslating]
+  );
+
+  return (
+    <LanguageContext.Provider
+      value={{ language, setLanguage, t, translateDynamic, isTranslating, translateAllPageText }}
+    >
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error(
+      "useLanguage must be used within a LanguageProvider"
+    );
+  }
+  return context;
+};

--- a/src/pages/signup/SignUp2.tsx
+++ b/src/pages/signup/SignUp2.tsx
@@ -150,6 +150,7 @@ const SignUp2 = () => {
         phoneNumber: signupData.phoneNumber || null,
         birthDate: signupData.birthDate || null,
         gender: signupData.gender || null,
+        campus: campus,
       };
 
       console.log("회원가입 요청 데이터:", signupRequestData);
@@ -164,8 +165,8 @@ const SignUp2 = () => {
       
       alert("인증번호가 전송되었습니다. 메일함을 확인해주세요!");
       setIsCodeSent(true);
-      // 이메일을 signupData에 저장
-      setSignupData({ ...signupData, email: email });
+      // 이메일과 캠퍼스를 signupData에 저장
+      setSignupData({ ...signupData, email: email, campus: campus });
     } catch (error: any) {
       console.error("회원가입 요청 실패:", error.response?.data || error.message || error);
       alert(error.response?.data?.message || "인증번호 전송 중 오류가 발생했습니다.");
@@ -216,6 +217,7 @@ const SignUp2 = () => {
       const response = await axiosInstance.post("/api/auth/verify-code", {
         email: email,
         code: verificationCode,
+        campus: campus,
       });
 
       if (response.data.verified) {
@@ -262,11 +264,17 @@ const SignUp2 = () => {
           <ContentTitle>02 학교 이메일로 인증해주세요 </ContentTitle>
           <InputContainer>
             <SelectContainer>
-              <Label onClick={() => setCampus("GLOBAL")}>
+              <Label onClick={() => {
+                setCampus("GLOBAL");
+                setSignupData({ ...signupData, campus: "GLOBAL" });
+              }}>
                 <Circle selected={campus === "GLOBAL"} />
                 글로벌
               </Label>
-              <Label onClick={() => setCampus("SEOUL")}>
+              <Label onClick={() => {
+                setCampus("SEOUL");
+                setSignupData({ ...signupData, campus: "SEOUL" });
+              }}>
                 <Circle selected={campus === "SEOUL"} />
                 서울
               </Label>

--- a/src/utils/autoTranslatePage.ts
+++ b/src/utils/autoTranslatePage.ts
@@ -1,0 +1,150 @@
+import { translateText } from "../api/translateAPI";
+
+/**
+ * 페이지의 모든 텍스트 노드를 찾아서 자동으로 번역하는 유틸리티
+ * DOM 기반으로 작동하므로 React 컴포넌트 외부에서도 사용 가능
+ */
+/**
+ * 페이지의 모든 텍스트 노드를 찾아서 자동으로 번역하는 유틸리티
+ * 주의: DOM 직접 조작은 React와 충돌하고 레이아웃을 깨뜨릴 수 있으므로
+ * 가능한 한 React 컴포넌트 레벨에서 번역 키를 사용하는 것을 권장합니다.
+ * 
+ * 이 함수는 레이아웃에 영향을 주지 않도록 더 보수적으로 작동합니다.
+ */
+export const translatePageText = async (targetLang: "한국어" | "영어" = "영어") => {
+  // React로 관리되는 요소는 건드리지 않도록 더 보수적인 선택자 사용
+  // 주로 placeholder나 title 같은 속성만 번역
+  const attributeSelectors = [
+    "input[placeholder]",
+    "textarea[placeholder]",
+    "[title]",
+    "[aria-label]"
+  ];
+
+  const elements: HTMLElement[] = [];
+  attributeSelectors.forEach(selector => {
+    const found = document.querySelectorAll(selector);
+    found.forEach(el => {
+      if (el instanceof HTMLElement) {
+        elements.push(el);
+      }
+    });
+  });
+
+  // 중복 제거
+  const uniqueElements = Array.from(new Set(elements));
+  
+  // 배치로 번역 (너무 많은 요청 방지)
+  const batchSize = 5;
+  for (let i = 0; i < uniqueElements.length; i += batchSize) {
+    const batch = uniqueElements.slice(i, i + batchSize);
+    
+    await Promise.all(
+      batch.map(async (el) => {
+        // placeholder 번역
+        if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+          const placeholder = el.placeholder?.trim();
+          if (placeholder && !el.dataset.translatedPlaceholder) {
+            try {
+              const response = await translateText({
+                text: placeholder,
+                targetLang: targetLang,
+              });
+
+              if (response.translatedText && response.translatedText !== placeholder) {
+                el.dataset.originalPlaceholder = placeholder;
+                el.placeholder = response.translatedText;
+                el.dataset.translatedPlaceholder = "true";
+              }
+            } catch (error) {
+              console.error(`placeholder 번역 실패 (${placeholder}):`, error);
+            }
+          }
+        }
+
+        // title 속성 번역
+        const title = el.getAttribute("title");
+        if (title && !el.dataset.translatedTitle) {
+          try {
+            const response = await translateText({
+              text: title,
+              targetLang: targetLang,
+            });
+
+            if (response.translatedText && response.translatedText !== title) {
+              el.dataset.originalTitle = title;
+              el.setAttribute("title", response.translatedText);
+              el.dataset.translatedTitle = "true";
+            }
+          } catch (error) {
+            console.error(`title 번역 실패 (${title}):`, error);
+          }
+        }
+
+        // aria-label 속성 번역
+        const ariaLabel = el.getAttribute("aria-label");
+        if (ariaLabel && !el.dataset.translatedAriaLabel) {
+          try {
+            const response = await translateText({
+              text: ariaLabel,
+              targetLang: targetLang,
+            });
+
+            if (response.translatedText && response.translatedText !== ariaLabel) {
+              el.dataset.originalAriaLabel = ariaLabel;
+              el.setAttribute("aria-label", response.translatedText);
+              el.dataset.translatedAriaLabel = "true";
+            }
+          } catch (error) {
+            console.error(`aria-label 번역 실패 (${ariaLabel}):`, error);
+          }
+        }
+      })
+    );
+
+    // 배치 간 약간의 지연 (API 부하 방지)
+    if (i + batchSize < uniqueElements.length) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+};
+
+/**
+ * 번역을 되돌리는 함수
+ */
+export const revertPageTranslation = () => {
+  // placeholder 복원
+  const translatedPlaceholders = document.querySelectorAll("[data-translated-placeholder='true']");
+  translatedPlaceholders.forEach(el => {
+    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+      const original = el.dataset.originalPlaceholder;
+      if (original) {
+        el.placeholder = original;
+        el.removeAttribute("data-translated-placeholder");
+        el.removeAttribute("data-original-placeholder");
+      }
+    }
+  });
+
+  // title 복원
+  const translatedTitles = document.querySelectorAll("[data-translated-title='true']");
+  translatedTitles.forEach(el => {
+    const original = el.getAttribute("data-original-title");
+    if (original && el instanceof HTMLElement) {
+      el.setAttribute("title", original);
+      el.removeAttribute("data-translated-title");
+      el.removeAttribute("data-original-title");
+    }
+  });
+
+  // aria-label 복원
+  const translatedAriaLabels = document.querySelectorAll("[data-translated-aria-label='true']");
+  translatedAriaLabels.forEach(el => {
+    const original = el.getAttribute("data-original-aria-label");
+    if (original && el instanceof HTMLElement) {
+      el.setAttribute("aria-label", original);
+      el.removeAttribute("data-translated-aria-label");
+      el.removeAttribute("data-original-aria-label");
+    }
+  });
+};


### PR DESCRIPTION
## 📌 PR 개요
- 회원가입 Step2에서 캠퍼스 값이 저장 및 전송되지 않던 문제 수정
- 인증번호 전송 및 확인 API 요청에 캠퍼스 값 포함
- 캠퍼스 선택 시 즉시 signupData에 저장되도록 개선

## 🔗 관련 이슈

## 🛠 변경 내용
- **SignUp2.tsx**
  - `handleSendCode`: 회원가입 요청 데이터에 `campus` 필드 추가
  - `handleVerifyCode`: 인증번호 확인 요청에 `campus` 필드 추가
  - 캠퍼스 선택 시 즉시 `signupData`에 저장되도록 수정
  - 인증번호 전송 성공 시 `campus` 값도 함께 저장


