### PR TITLE
feat: 스터디 신청한 멤버 리스트 컴포넌트 퍼블리싱 및 api 연결, comment ui 수정

### DIFF
--- a/src/components/CommentSection.tsx
+++ b/src/components/CommentSection.tsx
@@ -101,7 +101,7 @@ const CommentHeader = styled.div`
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 `;
 
 const CommentIcon = styled.img`

--- a/src/components/StudyApplicantsList.tsx
+++ b/src/components/StudyApplicantsList.tsx
@@ -1,0 +1,227 @@
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import type { StudyMember } from "../../types/study.types";
+
+import AmericaProfileImg from "../assets/img-profile1-America.svg";
+import KoreaProfileImg from "../assets/img-profile1-Korea.svg";
+import ItalyProfileImg from "../assets/img-profile1-Italy.svg";
+import EgyptProfileImg from "../assets/img-profile1-Egypt.svg";
+import ChinaProfileImg from "../assets/img-profile1-China.svg";
+
+
+// 국가별 캐릭터 이미지 매핑
+const countryCharacterImages: { [key: string]: string } = {
+  US: AmericaProfileImg,
+  KR: KoreaProfileImg,
+  IT: ItalyProfileImg,
+  EG: EgyptProfileImg,
+  CN: ChinaProfileImg,
+};
+
+// StudyDetail이랑 동일하게 BASE_URL 보정 (상대경로 대비 - 절대경로)
+const BASE_URL = (import.meta as any).env?.VITE_API_BASE_URL as string;
+
+const toAbsoluteUrl = (url: string | null | undefined) => {
+  if (!url) return "";
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+
+  const normalizedBase = BASE_URL?.endsWith("/")
+    ? BASE_URL.slice(0, -1)
+    : BASE_URL || "";
+  const normalizedPath = url.startsWith("/") ? url : `/${url}`;
+
+  return normalizedBase ? `${normalizedBase}${normalizedPath}` : normalizedPath;
+};
+
+const normalizeProfileUrl = (url?: string | null) => {
+  if (!url || url.trim() === "") return null;
+  return toAbsoluteUrl(url).replace(/([^:]\/)\/+/g, "$1");
+};
+
+const getMemberProfileImage = (member: StudyMember) => {
+  const countryUpper = member.country ? member.country.toUpperCase() : null;
+  const fallback =
+    (countryUpper && countryCharacterImages[countryUpper]) || KoreaProfileImg;
+
+  const profileUrl = normalizeProfileUrl(member.profileImageUrl);
+  return profileUrl || fallback;
+};
+
+interface Props {
+  members: StudyMember[];
+  isLoading: boolean;
+
+  //현재 로그인 유저(currentuser)와 작성자 비교 필요
+  currentUserId?: number;
+  authorId: number;
+}
+
+const StudyApplicantsList = ({ members, isLoading, currentUserId, authorId }: Props) => {
+  const navigate = useNavigate();
+  const handleGoProfile = (userId: number) => {
+    navigate(`/profile/${userId}`);
+  };
+  
+    return (
+    <Card>
+      <Header>
+        <Title className="H4">해당 스터디에 신청한 사람들</Title>
+        <SubTitle className="Body2">
+          다같이 열심히 공부해봐부!! {members.length > 0 ? `(신청 인원: ${members.length}명)` : ""}
+        </SubTitle>
+      </Header>
+
+      {isLoading ? (
+        <StateText className="Body2">불러오는 중...</StateText>
+      ) : members.length === 0 ? (
+        <StateText className="Body2">아직 신청한 사람이 없어요.</StateText>
+      ) : (
+        <List>
+          {members.map((member) => {
+            const isAuthorRow = member.userId === authorId;
+            const isMeRow = currentUserId != null && member.userId === currentUserId;
+
+            // 더보기 버튼 노출 조건
+            const showMoreButton = !isMeRow;
+
+            return (
+              <Row key={member.userId}>
+                <Avatar src={getMemberProfileImage(member)} alt={member.nickname} />
+                <Info>
+                  <NameLine>
+                    <Nickname className="Button1">{member.nickname}</Nickname>
+                    {isAuthorRow && <AuthorText className="Button1">· 작성자</AuthorText>}
+                  </NameLine>
+
+                    <Meta className="Body2">
+                    {(member.mbti || member.campus) && (
+                        <MetaChip className="Body3">
+                        {[ 
+                            member.mbti,
+                            member.campus &&
+                            (member.campus === "SEOUL" ? "서울캠퍼스" : "글로벌캠퍼스"),
+                        ]
+                            .filter(Boolean)
+                            .join(" · ")}
+                        </MetaChip>
+                    )}
+                    </Meta>
+                </Info>
+
+                {showMoreButton && (
+                  <MoreButton
+                    type="button"
+                    className="Button2"
+                    onClick={() => handleGoProfile(member.userId)}
+                  >
+                    더 보기 &gt;
+                  </MoreButton>
+                )}
+              </Row>
+            );
+          })}
+        </List>
+      )}
+    </Card>
+  );
+};
+
+export default StudyApplicantsList;
+
+const Card = styled.div`
+  background-color: var(--white);
+  border: 1px solid var(--gray);
+  border-radius: 1rem;
+  padding: 1.5rem;
+`;
+
+const Header = styled.div`
+  margin-bottom: 1rem;
+`;
+
+const Title = styled.div`
+  margin-bottom: 0.25rem;
+  color: var(--black);
+`;
+
+const SubTitle = styled.div`
+  color: var(--gray-700);
+`;
+
+const StateText = styled.div`
+  padding: 1rem 0;
+  color: var(--gray-700);
+`;
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+`;
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`;
+
+const Avatar = styled.img`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--gray);
+  flex-shrink: 0;
+`;
+
+const Info = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const NameLine = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+`;
+
+const Nickname = styled.div`
+  color: var(--black);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const AuthorText = styled.span`
+  color: #2F96B4;
+  flex-shrink: 0;
+  font-size: 11px;
+`;
+
+const Meta = styled.div`
+  color: var(--gray-700);
+  margin-top: 0.2rem;
+`;
+
+const MoreButton = styled.button`
+  border: none;
+  background: transparent;
+  color: var(--gray-700);
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  flex-shrink: 0;
+
+  &:hover {
+    color: var(--skyblue);
+    text-decoration: underline;
+  }
+`;
+
+const MetaChip = styled.span`
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background-color: var(--gray-text-filled);
+  color: var(--gray-700);
+  flex-shrink: 0;
+`;

--- a/src/pages/study/StudyDetail.tsx
+++ b/src/pages/study/StudyDetail.tsx
@@ -1,4 +1,3 @@
-// src/components/study/StudyDetail.tsx
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import styled from "styled-components";
@@ -24,7 +23,8 @@ import type {
     StudyStatus
 } from "../../types/study.types";
 
-//목데이터 삭제함
+import StudyApplicantsList from "../../components/StudyApplicantsList";
+import type { StudyMember } from "../../types/study.types";
 
 import ParticipantImg from "../../assets/img-participant.svg";
 import AmericaProfileImg from "../../assets/img-profile1-America.svg";
@@ -279,6 +279,10 @@ const StudyDetail = () => {
 // 가입 여부, 가입 요청 중 여부 구분
     const [hasJoined, setHasJoined] = useState(false);
     const [isJoining, setIsJoining] = useState(false);
+// 신청한 사람들 목록 state
+    const [members, setMembers] = useState<StudyMember[]>([]);
+    const [isMembersLoading, setIsMembersLoading] = useState(false);
+
 
     const useDefaultProfile =
   typeof window !== "undefined" &&
@@ -311,6 +315,21 @@ const StudyDetail = () => {
 
 
 
+const fetchMembers = useCallback(async () => {
+  if (isNaN(studyId)) return;
+
+  setIsMembersLoading(true);
+  try {
+    const res = await axiosInstance.get(`/api/studies/${studyId}/members`);
+    setMembers(res.data?.data ?? []);
+  } catch (e) {
+    console.error("신청자(멤버) 조회 실패:", e);
+    setMembers([]);
+  } finally {
+    setIsMembersLoading(false);
+  }
+}, [studyId]);
+
 
 const fetchComments = useCallback(async () => {
   setIsCommentsLoading(true);
@@ -332,8 +351,6 @@ const fetchComments = useCallback(async () => {
   }
 }, [studyId]);
 
-
-
 const fetchStudyDetail = useCallback(async () => {
   if (isNaN(studyId)) return;
 
@@ -352,7 +369,8 @@ const fetchStudyDetail = useCallback(async () => {
 useEffect(() => {
   fetchStudyDetail();
   fetchComments();
-}, [fetchStudyDetail, fetchComments]);
+  fetchMembers();
+}, [fetchStudyDetail, fetchComments, fetchMembers]);
 
 
 
@@ -429,8 +447,7 @@ useEffect(() => {
 };
 
 //중복 확인 및 처리
-// 이미 가입하기 했을 경우 API 호출 자체를 안 보내도록 
-//제발 좀 되길..죄송합니다..
+// 이미 가입하기 했을 경우 API 호출 자체를 안 보내도록 처리
 
     const handleJoinStudy = async () => {
     if (!studyDetail) return;
@@ -481,6 +498,9 @@ useEffect(() => {
             }
           : prev
       );
+
+      // 🔹 신청한 사람들 목록 갱신
+      await fetchMembers();
 
       // 🔹 필요하면 백엔드 최신 데이터로 다시 동기화
       // await fetchStudyDetail();
@@ -623,6 +643,11 @@ useEffect(() => {
       </ActionButton>
     </ButtonGroup>
   </UserProfileCard>
+  <StudyApplicantsList 
+  members={members} 
+  isLoading={isMembersLoading}
+  currentUserId={currentUserId}
+  authorId={studyData.authorId} />
 </LeftPanel>
 
 

--- a/src/types/study.types.ts
+++ b/src/types/study.types.ts
@@ -120,3 +120,13 @@ export interface UserProfileCard {
   profileImage: string | null;
   country: string;
 }
+
+// studymember 타입
+export interface StudyMember {
+  userId: number;
+  nickname: string;
+  profileImageUrl: string | null;
+  country: string | null;
+  mbti: string | null;
+  campus: "SEOUL" | "GLOBAL" | null;
+}


### PR DESCRIPTION
## 📌 PR 개요
- 스터디 디테일 페이지 좌측에 **신청자 목록 UI를 API 데이터 기반으로 구현**했습니다.
- 백엔드 응답값에 **MBTI, 캠퍼스 정보가 포함됨에 따라**, 기존 디자인을 유지하되 **정보 노출 방식과 UI 위계를 조정**하여 가독성을 개선했습니다.
- 신청자별 **프로필 상세 페이지로 이동할 수 있는 동선(더 보기)** 을 추가했습니다.

## 🔗 관련 이슈
- close #189 
- close #190 


## 🛠 변경 내용
### 0. CommentHeader 2rem -> 1rem으로 수정하여 간격 줄임

### 1. 스터디 신청자 목록 API 연동
- `/api/studies/{studyId}/members` API를 통해 신청자 목록 조회
- `StudyDetail`에서 신청자 목록 관련 상태 관리
  - `members`, `isMembersLoading` 상태 추가
  - 상세 페이지 진입 시 신청자 목록 조회 로직(`fetchMembers`) 호출
- `StudyApplicantsList` 컴포넌트에 아래 props 전달
  - `members`, `isLoading`
  - `currentUserId` (로컬 스토리지 기반)
  - `authorId` (스터디 작성자 ID)

### 2. 신청자 목록 UI 구성 및 개선
- **프로필 이미지 처리**
  - 서버에서 상대경로로 내려오는 이미지 URL을 `BASE_URL` 기준 절대경로로 보정
  - 프로필 이미지가 없는 경우, 국가 코드 기반 캐릭터 이미지 fallback 적용

- **작성자 표시 방식 개선**
  - 작성자는 닉네임 옆에 `· 작성자` 텍스트로 표시
  - 기존 칩 형태 대신 텍스트 강조 방식으로 변경하여
    - 역할 정보임을 명확히 하되
    - UI가 과도하게 복잡해 보이지 않도록 조정

- **MBTI / 캠퍼스 정보 노출 방식 변경**
  - 백엔드 응답에 `mbti`, `campus` 값이 포함됨에 따라 UI 반영
  - 기존 디자인 흐름을 유지하면서,
    - 개별 칩 여러 개로 나누지 않고
    - 하나의 MetaChip 안에 `MBTI · 캠퍼스` 형태로 결합하여 노출
  - 정보는 유지하되, 리스트 UI가 과도하게 분산되지 않도록 정리

- **더 보기 버튼 노출 조건 정리**
  - 신청자 행 클릭 시 `/profile/:userId`로 이동
  - 현재 로그인한 사용자 본인의 행에서는 더 보기 버튼 미노출
  - 그 외 신청자(작성자 포함)는 더 보기 버튼 노출

## 🧪 확인 사항
- [x] 로컬에서 정상 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능 정상 동작 유지
- [x] 불필요한 API 호출 없음

## 📝 비고
- 공통 유틸(`toAbsoluteUrl`, `normalizeProfileUrl`)은 추후 분리 가능
- 신청자 목록 정렬 기준(작성자 고정, 신청 순 등)은 정책 확정 후 추가 개선 예정

