### PR TITLE
fix: 인증번호확인 요청보낼때 캠퍼스 추가

### DIFF
--- a/src/pages/signup/SignUp2.tsx
+++ b/src/pages/signup/SignUp2.tsx
@@ -219,6 +219,7 @@ const SignUp2 = () => {
       const response = await axiosInstance.post("/api/auth/verify-code", {
         email: email,
         code: verificationCode,
+        campus: campus,
       });
 
       if (response.data.verified) {


### PR DESCRIPTION
## 📌 PR 개요
- 회원가입 2단계에서 이메일 인증번호 확인 요청 시 campus 값도 함께 전송되도록 수정

## 🔗 관련 이슈
- close #이슈번호 (없으면 생략)

## 🛠 변경 내용
- /signup/step2 페이지에서 인증번호 확인 API(/api/auth/verify-code) 호출 시 요청 바디에 campus 필드를 추가
- 기존에는 { email, code }만 전송하던 로직을 { email, code, campus }로 확장하여, 백엔드에서 캠퍼스 정보 기반 검증/처리가 가능하도록 반영

