### PR TITLE
feat: 쪽지, 채팅 쪽 번역

### DIFF
--- a/src/components/CommentSection.tsx
+++ b/src/components/CommentSection.tsx
@@ -245,7 +245,7 @@ const CommentSection = ({
   };
 
   const handleDeleteComment = (commentId: number) => {
-    if (confirm(t("mypage.confirm.deleteComment"))) {
+    if (confirm(t("study.detail.comments.deleteConfirm"))) {
       onDeleteComment(commentId);
     }
   };

--- a/src/components/StudyApplicantsList.tsx
+++ b/src/components/StudyApplicantsList.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import type { StudyMember } from "../../types/study.types";
 
 import { COUNTRY_ASSETS } from "../utils/countryAssets";
@@ -48,7 +49,9 @@ interface Props {
 }
 
 const StudyApplicantsList = ({ members, isLoading, currentUserId, authorId }: Props) => {
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
+  const isEnglish = i18n.language === 'en';
   const handleGoProfile = (userId: number) => {
     navigate(`/profile/${userId}`);
   };
@@ -56,16 +59,30 @@ const StudyApplicantsList = ({ members, isLoading, currentUserId, authorId }: Pr
     return (
     <Card>
       <Header>
-        <Title className="H4">해당 스터디에 신청한 사람들</Title>
+        <Title className="H4">{t("study.detail.applicants.title")}</Title>
         <SubTitle className="Body2">
-          다같이 열심히 공부해봐부!! {members.length > 0 ? `(신청 인원: ${members.length}명)` : ""}
+          {isEnglish ? (
+            <>
+              {t("study.detail.applicants.subtitle")}
+              {members.length > 0 && (
+                <>
+                  <br />
+                  ({t("study.detail.applicants.applicantCount")}: {members.length}{t("study.detail.participants")})
+                </>
+              )}
+            </>
+          ) : (
+            <>
+              {t("study.detail.applicants.subtitle")} {members.length > 0 ? `(${t("study.detail.applicants.applicantCount")}: ${members.length}${t("study.detail.participants")})` : ""}
+            </>
+          )}
         </SubTitle>
       </Header>
 
       {isLoading ? (
-        <StateText className="Body2">불러오는 중...</StateText>
+        <StateText className="Body2">{t("study.detail.applicants.loading")}</StateText>
       ) : members.length === 0 ? (
-        <StateText className="Body2">아직 신청한 사람이 없어요.</StateText>
+        <StateText className="Body2">{t("study.detail.applicants.empty")}</StateText>
       ) : (
         <List>
           {members.map((member) => {
@@ -81,7 +98,7 @@ const StudyApplicantsList = ({ members, isLoading, currentUserId, authorId }: Pr
                 <Info>
                   <NameLine>
                     <Nickname className="Button1">{member.nickname}</Nickname>
-                    {isAuthorRow && <AuthorText className="Button1">· 작성자</AuthorText>}
+                    {isAuthorRow && <AuthorText className="Button1">· {t("study.detail.author")}</AuthorText>}
                   </NameLine>
 
                     <Meta className="Body2">
@@ -90,7 +107,7 @@ const StudyApplicantsList = ({ members, isLoading, currentUserId, authorId }: Pr
                         {[ 
                             member.mbti,
                             member.campus &&
-                            (member.campus === "SEOUL" ? "서울캠퍼스" : "글로벌캠퍼스"),
+                            (member.campus === "SEOUL" ? t("profile.campus.seoul") : t("profile.campus.global")),
                         ]
                             .filter(Boolean)
                             .join(" · ")}
@@ -105,7 +122,7 @@ const StudyApplicantsList = ({ members, isLoading, currentUserId, authorId }: Pr
                     className="Button2"
                     onClick={() => handleGoProfile(member.userId)}
                   >
-                    더 보기 &gt;
+                    {t("common.more")}
                   </MoreButton>
                 )}
               </Row>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -624,6 +624,14 @@
         "closed": "Closed"
       },
       "participants": "people",
+      "author": "Author",
+      "applicants": {
+        "title": "People who applied for this study",
+        "subtitle": "Let's all study hard together!!",
+        "applicantCount": "Applicants",
+        "loading": "Loading...",
+        "empty": "No one has applied yet."
+      },
       "actions": {
         "edit": "Edit",
         "delete": "Delete",
@@ -646,6 +654,17 @@
         "joinConfirm": "Do you want to request to join this study?",
         "joinSuccess": "Join request sent successfully.",
         "joinError": "Failed to join study:"
+      },
+      "comments": {
+        "title": "Please write a comment!",
+        "description": "Feel free to write any questions or consultations about this study.",
+        "placeholder": "Enter your comment",
+        "submit": "Post Comment",
+        "listTitle": "Comments",
+        "loading": "Loading comments...",
+        "editPrompt": "Edit your comment:",
+        "deleteConfirm": "Are you sure you want to delete this comment?",
+        "iconAlt": "Comment icon"
       }
     },
     "post": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -624,6 +624,14 @@
         "closed": "마감"
       },
       "participants": "명",
+      "author": "작성자",
+      "applicants": {
+        "title": "해당 스터디에 신청한 사람들",
+        "subtitle": "다같이 열심히 공부해봐부!!",
+        "applicantCount": "신청 인원",
+        "loading": "불러오는 중...",
+        "empty": "아직 신청한 사람이 없어요."
+      },
       "actions": {
         "edit": "수정하기",
         "delete": "삭제하기",
@@ -646,6 +654,17 @@
         "joinConfirm": "스터디에 가입 요청을 하시겠습니까?",
         "joinSuccess": "스터디 가입 요청을 성공적으로 보냈습니다.",
         "joinError": "스터디 가입 요청에 실패했습니다:"
+      },
+      "comments": {
+        "title": "댓글을 작성해주세요!",
+        "description": "해당 스터디에 대한 궁금한 점이나 상담을 자유롭게 작성해주세요.",
+        "placeholder": "댓글을 입력하세요",
+        "submit": "댓글 작성하기",
+        "listTitle": "댓글",
+        "loading": "댓글을 불러오는 중...",
+        "editPrompt": "댓글을 수정하세요:",
+        "deleteConfirm": "댓글을 삭제하시겠습니까?",
+        "iconAlt": "댓글 아이콘"
       }
     },
     "post": {

--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -217,6 +217,24 @@ const SendButton = styled.div`
   background: var(--skyblue, #66CAE7);
   cursor: pointer;
 `
+
+const TranslateText = styled.span`
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--skyblue, #66CAE7);
+  cursor: pointer;
+  text-decoration: underline;
+  display: block;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`
 export default function Message() {
 
   const { t } = useTranslation();
@@ -232,6 +250,9 @@ export default function Message() {
   };
   
   const [messages, setMessages] = useState<MessageItem[]>([]);
+  // 번역 상태를 별도로 관리 (메시지 갱신 시에도 유지)
+  const [translations, setTranslations] = useState<Map<number, string>>(new Map());
+  const [translatingIds, setTranslatingIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     const fetchChatRooms = async () => {
@@ -283,6 +304,7 @@ export default function Message() {
         const res = await axiosInstance.get(`/api/messages/${selectedProfile.id}`);
         console.log(` ${selectedProfile.username}과의 대화 조회 성공:`, res.data);
   
+        // 번역 상태는 별도 state로 관리하므로 메시지만 업데이트
         const formattedMessages = res.data.map((msg: any) => ({
           id: msg.id,
           message: msg.content,
@@ -307,7 +329,60 @@ export default function Message() {
 
   const [newMessage, setNewMessage] = useState("");
 
+  // 텍스트가 한글인지 영어인지 감지하는 함수
+  const detectLanguage = (text: string): 'ko' | 'en' => {
+    const koreanRegex = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/;
+    return koreanRegex.test(text) ? 'ko' : 'en';
+  };
 
+  // 번역 함수
+  const handleTranslate = async (messageId: number, originalText: string) => {
+    try {
+      // 번역 중 상태로 설정
+      setTranslatingIds((prev) => new Set(prev).add(messageId));
+
+      // 언어 감지 및 타겟 언어 결정
+      const sourceLang = detectLanguage(originalText);
+      const targetLang = sourceLang === 'ko' ? 'en' : 'ko';
+
+      // 번역 API 호출
+      const res = await axiosInstance.post('/api/translate', {
+        text: originalText,
+        targetLang: targetLang,
+      });
+
+      // API 응답에서 번역된 텍스트 추출
+      const translatedText = res.data?.translatedText || res.data?.text || res.data?.data?.translatedText || res.data?.data?.text || res.data;
+
+      // 번역된 텍스트가 문자열인지 확인
+      if (typeof translatedText !== 'string') {
+        throw new Error('번역된 텍스트 형식이 올바르지 않습니다.');
+      }
+
+      // 번역된 텍스트를 별도 state에 저장 (메시지 갱신 시에도 유지)
+      setTranslations((prev) => {
+        const newMap = new Map(prev);
+        newMap.set(messageId, translatedText);
+        return newMap;
+      });
+
+      // 번역 중 상태 제거
+      setTranslatingIds((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(messageId);
+        return newSet;
+      });
+    } catch (error) {
+      console.error('번역 실패:', error);
+      alert('번역에 실패했습니다.');
+      // 번역 중 상태 제거
+      setTranslatingIds((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(messageId);
+        return newSet;
+      });
+    }
+  };
 
   const handleSendMessage = async () => {
     if (!selectedProfile || newMessage.trim() === "") return;
@@ -471,9 +546,35 @@ export default function Message() {
                             borderRadius: msg.isMine
                               ? "0.75rem 0 0.75rem 0.75rem" // 오른쪽 말풍선
                               : "0 0.75rem 0.75rem 0.75rem", // 왼쪽 말풍선
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: msg.isMine ? 'flex-end' : 'flex-start',
                           }}
                         >
-                          {msg.message}
+                          <div>{translations.get(msg.id) || msg.message}</div>
+                          <TranslateText
+                            onClick={() => {
+                              if (translations.get(msg.id)) {
+                                // 원문 보기: 번역된 텍스트 제거
+                                setTranslations((prev) => {
+                                  const newMap = new Map(prev);
+                                  newMap.delete(msg.id);
+                                  return newMap;
+                                });
+                              } else {
+                                // 번역하기: 번역 API 호출
+                                handleTranslate(msg.id, msg.message);
+                              }
+                            }}
+                            style={{
+                              pointerEvents: translatingIds.has(msg.id) ? 'none' : 'auto',
+                              opacity: translatingIds.has(msg.id) ? 0.5 : 1,
+                              alignSelf: msg.isMine ? 'flex-end' : 'flex-start',
+                              color: msg.isMine ? '#FFFFFF' : 'var(--skyblue, #66CAE7)',
+                            }}
+                          >
+                            {translatingIds.has(msg.id) ? '번역 중...' : translations.get(msg.id) ? '원문 보기' : '번역하기'}
+                          </TranslateText>
                         </MessageBox>
                         
                         {msg.isMine && (
@@ -482,6 +583,7 @@ export default function Message() {
                               fontSize: "0.75rem",
                               color: msg.isRead ? "#7C8A9A" : "#C0C0C0",
                               marginTop: "0.25rem",
+                              textAlign: "right",
                             }}
                           >
                             {msg.isRead ? t("message.chat.read") : t("message.chat.sent")}

--- a/src/pages/study/StudyDetail.tsx
+++ b/src/pages/study/StudyDetail.tsx
@@ -577,7 +577,7 @@ useEffect(() => {
                 <LeftPanel>
   <UserProfileCard>
     {isUserLoading ? (
-      <p>사용자 정보 로딩 중...</p>
+      <p>{t("study.detail.profile.loading")}</p>
     ) : userMe ? (
       (() => {
         const myCountryCode = userMe.country?.toUpperCase();
@@ -602,7 +602,7 @@ useEffect(() => {
         );
       })()
     ) : (
-      <p>로그인이 필요합니다.</p>
+      <p>{t("study.detail.profile.loginRequired")}</p>
     )}
 
     <ButtonGroup>
@@ -611,21 +611,21 @@ useEffect(() => {
         className="Button1"
         onClick={handleMyPostsClick}
       >
-        작성한 게시글
+        {t("study.detail.profile.myPosts")}
       </ActionButton>
       <ActionButton
         $variant="secondary"
         className="Button1"
         onClick={handleMyCommentsClick}
       >
-        작성한 댓글
+        {t("study.detail.profile.myComments")}
       </ActionButton>
       <ActionButton
         $variant="primary"
         className="Button1"
         onClick={handleBackToList}
       >
-        스터디 목록
+        {t("study.detail.profile.backToList")}
       </ActionButton>
     </ButtonGroup>
   </UserProfileCard>
@@ -645,7 +645,7 @@ useEffect(() => {
                             <StudyAuthorSection>
                                 <StudyAuthorImage
                   src={finalAuthorProfileImage}
-                  alt="작성자"
+                  alt={t("study.detail.author")}
                 />
                                 <AuthorName className="H4">
                                     {studyData.authorNickname}


### PR DESCRIPTION
## 📌 PR 개요
- 채팅 메시지에 번역 기능 추가 (한국어 ↔ 영어)
- Message.tsx와 RandomMatchCard.tsx에 번역하기 기능 구현
- 번역된 텍스트 표시 및 원문 보기 기능 추가

## 🔗 관련 이슈
- (이슈 번호가 있으면 추가)

## 🛠 변경 내용

### 주요 기능 추가
- **번역 API 연동**: `/api/translate` 사용하여 메시지 번역
- **언어 자동 감지**: 한글/영어 자동 감지 후 반대 언어로 번역
- **번역 상태 관리**: 번역된 텍스트를 별도 state(Map)로 관리하여 메시지 갱신 시에도 유지
- **원문 보기**: 번역된 텍스트에서 원문으로 복원 기능

### 수정/추가된 파일
- `FE/src/pages/Message.tsx`
  - 번역 상태 관리 state 추가 (`translations`, `translatingIds`)
  - `detectLanguage` 함수 추가 (한글/영어 감지)
  - `handleTranslate` 함수 추가 (번역 API 호출)
  - `TranslateText` 스타일 컴포넌트 추가
  - 메시지 렌더링에 번역 기능 통합

- `FE/src/components/RandomMatchCard.tsx`
  - Message.tsx와 동일한 번역 기능 추가
  - 채팅 화면에 번역하기 기능 통합

### UI 개선
- 번역하기 버튼을 말풍선 안으로 이동 (버튼 스타일 → 텍스트 링크)
- 내 메시지(파란색 배경)일 때 번역하기 텍스트 색상을 흰색으로 변경 (가독성 개선)
- 원본 텍스트와 번역하기 사이 간격 조정 (0.5rem → 0.25rem)
- 말풍선 border-radius 통일 (RandomMatchCard: 2rem → 0.75rem, Message.tsx와 동일하게)

### 버그 수정
- RandomMatchCard.tsx의 `partnerCountryCode` 변수 들여쓰기 수정 (채팅 시작하기 버튼 작동 문제 해결)


