### PR TITLE
fix:마이페이지 무한 렌더링 해결

### DIFF
--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { useNavigate, useLocation } from "react-router-dom";
@@ -77,15 +77,19 @@ const Mypage = () => {
   const [myComments, setMyComments] = useState<Comment[]>([]);
   const [myAppliedStudies, setMyAppliedStudies] = useState<AppliedStudy[]>([]);
 
-  const LANGUAGE_MAP: Record<string, string> = Object.fromEntries(
-    SUPPORTED_LANGUAGE_CODES.map(code => [
-      code,
-      t(`randomMatch.languages.${code}`)
-    ])
+  const LANGUAGE_MAP: Record<string, string> = useMemo(() => 
+    Object.fromEntries(
+      SUPPORTED_LANGUAGE_CODES.map(code => [
+        code,
+        t(`randomMatch.languages.${code}`)
+      ])
+    ), [t]
   );
 
-  const LANGUAGE_REVERSE_MAP: Record<string, string> = Object.fromEntries(
-    Object.entries(LANGUAGE_MAP).map(([k, v]) => [v, k])
+  const LANGUAGE_REVERSE_MAP: Record<string, string> = useMemo(() => 
+    Object.fromEntries(
+      Object.entries(LANGUAGE_MAP).map(([k, v]) => [v, k])
+    ), [LANGUAGE_MAP]
   );
 
   const fetchMyKeywords = useCallback(async () => {


### PR DESCRIPTION
## 📌 PR 개요
- 마이페이지에서 다른 페이지로 이동이 안 되는 문제 해결
- `LANGUAGE_REVERSE_MAP` 객체가 매 렌더마다 새로 생성되어 발생한 무한 렌더링 루프 수정
- `useMemo`를 활용한 객체 메모이제이션 및 조건부 state 업데이트 로직 추가

## 🔗 관련 이슈

## 🛠 변경 내용

### 주요 수정 사항

#### 1. ProfileCard.tsx
- `useMemo` import 추가
- `LANGUAGE_REVERSE_MAP` 객체를 `useMemo`로 메모이제이션하여 매 렌더마다 재생성되는 문제 해결
- `languageOptions`도 `useMemo`로 메모이제이션
- `useEffect` 내부에 값 변경 확인 로직 추가하여 불필요한 state 업데이트 방지

**문제 원인**
객체 참조 동일성 문제: LANGUAGE_REVERSE_MAP가 매 렌더마다 새 객체로 생성되어 useEffect의 deps에서 항상 변경으로 인식
무한 루프 발생: deps 변경 감지 → setSelectedValues 실행 → state 업데이트 → 렌더링 → 객체 재생성 → 반복
페이지 이동 불가: 무한 렌더링으로 인해 React가 라우팅 처리를 할 수 없음

**해결 방법**
메모이제이션: useMemo로 객체를 메모이제이션하여 의존성(t)이 변경되지 않는 한 같은 참조 유지
조건부 업데이트: useEffect 내부에서 실제 값 변경 여부를 확인한 후에만 state 업데이트