### PR TITLE
fix: 프로필 배너 클릭 이동 삭제

### DIFF
--- a/src/pages/profile/ProfileLanding.tsx
+++ b/src/pages/profile/ProfileLanding.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import styled, { keyframes, css } from "styled-components";
 import { useNavigate } from "react-router-dom";
+import styled, { keyframes, css } from "styled-components";
 import { useTranslation } from "react-i18next";
 import ProfileBanner from "../../components/ProfileBanner";
 
@@ -338,10 +338,6 @@ const ProfileLanding: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const handleProfileClick = (userId: number) => {
-    navigate(`/profile/${userId}`);
-  };
-
   const handleExploreClick = () => {
     navigate('/profile');
   };
@@ -366,7 +362,6 @@ const ProfileLanding: React.FC = () => {
             key={profile.userId}
             $index={index}
             $size={getSizePattern(index)}
-            onClick={() => handleProfileClick(profile.userId)}
           >
             <ProfileBanner
               userId={profile.userId}


### PR DESCRIPTION
## 📌 PR 개요
- 랜딩 페이지(ProfileLanding)에서 프로필 배너 클릭 시 상세 페이지로 이동하던 동작을 제거하고, 전시용 UI로 동작하도록 수정
- 중앙 CTA 버튼을 통해서만 프로필 목록 페이지로 이동 가능하도록 네비게이션 구조 정리

## 🔗 관련 이슈
- close #187 

## 🛠 변경 내용

### 1. ProfileLanding 페이지 프로필 배너 클릭 이동 제거
- 랜딩 페이지에 배치된 떠있는 프로필 카드(FloatingProfile)에 연결되어 있던 `onClick` 네비게이션 로직 제거
- 프로필 배너가 **미리보기/전시용 요소**로만 동작하도록 수정

**변경 전**
- 프로필 배너 클릭 시 `/profile/:userId`로 이동

**변경 후**
- 프로필 배너 클릭 시 이동 없음
- hover 애니메이션 및 시각적 효과만 유지

---

### 2. FloatingProfile 컴포넌트 구조 정리
- `FloatingProfile` 컴포넌트에서 클릭 이벤트 제거
- 프로필 이동 로직을 상위 컴포넌트에서 완전히 분리하여, 랜딩 페이지의 역할을 명확히 함

```tsx
// 변경 전
<FloatingProfile onClick={() => handleProfileClick(profile.userId)} />

// 변경 후
<FloatingProfile />
