### PR TITLE
fix: 스터디 가입 관련 alert 수정

### DIFF
--- a/src/pages/study/StudyDetail.tsx
+++ b/src/pages/study/StudyDetail.tsx
@@ -271,6 +271,8 @@ const StudyDetail = () => {
     const [members, setMembers] = useState<StudyMember[]>([]);
     const [isMembersLoading, setIsMembersLoading] = useState(false);
 
+    const storedUserId = localStorage.getItem("userId");
+    const currentUserId = storedUserId ? Number(storedUserId) : undefined;
 
     const useDefaultProfile =
   typeof window !== "undefined" &&
@@ -309,14 +311,24 @@ const fetchMembers = useCallback(async () => {
   setIsMembersLoading(true);
   try {
     const res = await axiosInstance.get(`/api/studies/${studyId}/members`);
-    setMembers(res.data?.data ?? []);
+    const list = res.data?.data ?? [];
+
+    setMembers(list);
+
+    if (currentUserId != null) {
+      const alreadyJoined = list.some(
+        (member: any) => member.userId === currentUserId
+      );
+      setHasJoined(alreadyJoined);
+    }
   } catch (e) {
     console.error("신청자(멤버) 조회 실패:", e);
     setMembers([]);
   } finally {
     setIsMembersLoading(false);
   }
-}, [studyId]);
+}, [studyId, currentUserId]);
+
 
 
 const fetchComments = useCallback(async () => {
@@ -442,7 +454,7 @@ useEffect(() => {
 
     // ✅ 이미 한 번 가입한 상태 (이 페이지에서 한 번 성공한 이후)
     if (hasJoined) {
-      alert("이미 이 스터디에 가입하셨습니다.\n마이페이지에서 참여한 스터디를 확인해 주세요.");
+      alert("이미 이 스터디에 가입하셨습니다.\n마이페이지에서 참여한 스터디를 확인해 주세요!");
       return;
     }
 
@@ -457,7 +469,7 @@ useEffect(() => {
       typeof studyDetail.currentParticipants === "number" &&
       studyDetail.currentParticipants >= studyDetail.capacity
     ) {
-      alert("이미 정원이 가득 찬 스터디입니다.");
+      alert("이미 정원이 가득 찬 스터디입니다!");
       return;
     }
 
@@ -474,7 +486,7 @@ useEffect(() => {
       setIsJoining(true); // 🔹 요청 시작
 
       const res = await joinStudy(studyId);
-      alert(res.message || "스터디 가입 요청을 성공적으로 보냈습니다.");
+      alert("스터디 가입이 완료되었습니다.\n마이페이지에서 참여한 스터디를 확인해 주세요!");
 
       // 🔹 프론트 상태 즉시 반영
       setHasJoined(true);
@@ -521,8 +533,6 @@ useEffect(() => {
     }
     
     const studyData = studyDetail!;
-    const storedUserId = localStorage.getItem("userId");
-    const currentUserId = storedUserId ? Number(storedUserId) : undefined;
 
     const isAuthor = currentUserId != null && studyData.authorId === currentUserId;
       
@@ -711,7 +721,7 @@ useEffect(() => {
                           className="Button1"
                           onClick={handleJoinStudy}
                           style={{ marginTop: "1rem" }}
-                          disabled={hasJoined || isJoining}
+                          disabled={isJoining}
                         >
                           {hasJoined ? t("study.detail.actions.joined") : t("study.detail.actions.join")}
                         </JoinButton>


### PR DESCRIPTION
## 📌 PR 개요
- StudyDetail 페이지에서 스터디 가입 UX를 개선하고, 중복 가입 시 사용자에게 명확한 안내가 표시되도록 수정했습니다.

## 🔗 관련 이슈
- close #245 

## 🛠 변경 내용
- **StudyDetail**
  - 스터디 멤버 목록 조회 결과를 기반으로 현재 사용자의 가입 여부를 판별하도록 로직 추가
  - 이미 가입한 스터디인 경우 가입 API를 호출하지 않고 안내 alert가 표시되도록 처리
  - 가입 성공 시 백엔드 응답 메시지(`success`)를 그대로 노출하지 않고, 사용자 친화적인 문구로 alert 고정(res.response 삭제)
  - 가입 요청 중 중복 클릭을 방지하기 위해 가입 요청 상태(`isJoining`)를 기준으로 버튼 비활성화 처리
  - 가입 성공 시 멤버 목록을 다시 조회하여 화면 상태를 최신화

## 🧪 확인 사항
- [x] 로컬에서 정상 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능 정상 동작 유지
- [x] 불필요한 API 중복 호출 방지 처리 완료

## 📝 비고
- 현재는 프론트에서 가입 완료 문구를 고정하여 사용 중이며, 추후 다국어(i18n) 처리 시 메시지 분리 가능
- 멘트
`      alert("이미 이 스터디에 가입하셨습니다.\n마이페이지에서 참여한 스터디를 확인해 주세요!");
      alert("스터디 가입이 완료되었습니다.\n마이페이지에서 참여한 스터디를 확인해 주세요!");

`
