### PR TITLE
fix: studyPost 수정 시 캠캠퍼스 정보 불러오기

### DIFF
--- a/src/pages/study/StudyPost.tsx
+++ b/src/pages/study/StudyPost.tsx
@@ -250,12 +250,20 @@ const StudyPost = () => {
       try {
         const res = await getStudyDetail(studyId);
         const data = res.data;
+        // ✅ 백엔드 캠퍼스 값("서울"/"글로벌") → 프론트 코드("SEOUL"/"GLOBAL") 변환
+        const toCampusCode = (v?: string): 'SEOUL' | 'GLOBAL' | '' => {
+          if (!v) return '';
+          if (v === '서울') return 'SEOUL';
+          if (v === '글로벌') return 'GLOBAL';
+          return '';
+        };
+
 
         setFormData({
           title: data.title,
           content: data.content,
           status: data.status,
-          campus: (data.campuses?.[0] as 'SEOUL' | 'GLOBAL' | '') ?? "",
+          campus: toCampusCode(data.campuses?.[0]),
           language: data.languages?.[0] ?? "",
           capacity: data.capacity,
         });


### PR DESCRIPTION
## 📌 PR 개요
- StudyPost(게시글 작성/수정) 페이지에서 **수정하기 진입 시 캠퍼스 선택값이 초기화되는 이슈**를 해결함.
- 백엔드에서 내려주는 캠퍼스 값(`"서울" / "글로벌"`)과 프론트 Select가 사용하는 값(`"SEOUL" / "GLOBAL"`)의 **불일치로 인해 수정 화면에서 기본값으로 보이던 현상** 수정함.

## 🔗 관련 이슈
- close #254 

## 🛠 변경 내용
- **StudyPost 수정모드 초기 데이터 세팅 로직 개선**
  - `getStudyDetail(studyId)` 응답에서 내려오는 `campuses[0]` 값이 `"서울"` 형태로 내려와 `<select value="SEOUL|GLOBAL">`와 매칭되지 않아 선택값이 초기화되는 문제 확인
  - 백엔드 캠퍼스 문자열을 프론트에서 사용하는 코드 값으로 변환하는 유틸 함수(`toCampusCode`)를 추가
  - 수정 모드 진입 시 `setFormData`에서 `campus` 값을 아래처럼 변환 적용
    - `"서울"` → `"SEOUL"`
    - `"글로벌"` → `"GLOBAL"`
  - 그 결과, 수정 화면 진입 시 캠퍼스가 정상적으로 선택된 상태로 렌더링되도록 수정

- **변경 파일**
  - `StudyPost.tsx`
    - `toCampusCode` 변환 함수 추가
    - 수정 모드 데이터 로딩(`loadStudyForEdit`)의 `setFormData`에서 `campus` 값 매핑 로직 교체

## 🧪 확인 사항
- [x] 로컬에서 정상 동작 확인 (수정 화면 진입 시 캠퍼스 선택값 유지)
- [x] 타입 에러 없음
- [x] 기존 기능 정상 동작 유지 (작성/수정, 제목/내용/인원/언어 입력 로직 영향 없음)
- [x] 불필요한 API 호출 없음 (기존 `getStudyDetail` 호출 1회 유지)

## 📝 비고
- 백엔드 응답 스펙(`campuses: ["서울"]`)과 프론트 폼 스펙(`campus: "SEOUL" | "GLOBAL"`)이 달라 발생한 이슈로, 현재는 프론트에서 변환 처리로 대응했습니다.
- 추후 캠퍼스 값 스펙을 **서버/클라 중 한 쪽으로 통일**하면 변환 로직을 단순화할 수 도 있습니다.
