### PR TITLE
fix: mypage 인트로 제목, 내용 수정 후 이미지 업로드 시 정상 작동

### DIFF
--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -331,10 +331,11 @@ const handleAppliedStudyClick = (studyId: number) => {
           `?t=${Date.now()}`;
       }
   
-      setUserData({
-        ...refreshedUser,
-        _updateKey: Date.now(),
-      });
+      setUserData((prev: any) => ({
+  ...prev,
+  profileImageUrl: refreshedUser.profileImageUrl, // 또는 캐시버스터 붙인 값
+  _updateKey: Date.now(),
+}));
   
       alert("프로필 이미지가 성공적으로 업로드되었습니다!");
     } catch (error) {
@@ -357,15 +358,11 @@ const handleProfileImageReset = async () => {
 
     localStorage.setItem("useDefaultProfileImage", "true");
 
-    const refreshed = await axiosInstance.get("/api/users/me");
-    const refreshedUser = refreshed.data;
-
-    refreshedUser.profileImageUrl = null;
-
-    setUserData({
-      ...refreshedUser,
-      _updateKey: Date.now(),
-    });
+    setUserData((prev: any) => ({
+  ...prev,
+  profileImageUrl: null,
+  _updateKey: Date.now(),
+}));
 
     alert(t("mypage.alert.imageResetSuccess"));
   } catch (error) {
@@ -465,7 +462,6 @@ const filteredAppliedStudies = myAppliedStudies.filter(
         
           return (
             <ProfileCard
-              key={`${profileSrc}-${userData._updateKey || ""}`}
               userId={userData.id}
               username={userData.username}
               name={userData.name}


### PR DESCRIPTION
## 📌 PR 개요
- 마이페이지(ProfileCard) **프로필 편집 중 이미지 변경 시 입력값이 초기화되던 문제**를 수정했습니다.
- 프로필 이미지 업로드/리셋 과정에서 컴포넌트가 리마운트되며, 편집 중이던 `introTitle`, `introContent` 값이 이전 값으로 되돌아가던 현상을 해결했습니다.

## 🔗 관련 이슈
- close #257 

## 🛠 변경 내용
- **ProfileCard 리마운트 이슈 해결**
  - 이미지 변경 시 `ProfileCard`에 전달되던 `key` prop이 변경되며 컴포넌트가 리마운트되는 구조를 확인
  - 해당 `key`를 제거하여, 이미지 업로드/리셋 시에도 컴포넌트가 유지되도록 수정
  - 그 결과, 프로필 편집 모드에서 이미지 변경 후에도 `introTitle`, `introContent` 입력값이 유지됨

- **프로필 이미지 리셋 로직 개선**
  - 프로필 이미지 리셋 시 불필요하게 호출되던 `GET /api/users/me` API 제거
  - 서버에 이미지 삭제 요청(`DELETE /api/users/me/profile-image`) 후,
    기존 `userData`를 유지한 채 `profileImageUrl`만 `null`로 업데이트하도록 수정
  - 편집 중이던 사용자 정보가 이미지 변경으로 인해 덮어써지지 않도록 개선

- **프로필 이미지 업로드 시 상태 업데이트 방식 유지**
  - 이미지 업로드 후에도 `userData` 전체를 교체하지 않고,
    `profileImageUrl` 필드만 업데이트하여 기존 편집 상태 보존

- **변경 파일**
  - `Mypage.tsx`
    - `ProfileCard`의 `key` 제거
    - `handleProfileImageReset`에서 불필요한 사용자 정보 재조회 API 제거
    - 이미지 업로드/리셋 시 `userData` 부분 업데이트 방식 적용

## 🧪 확인 사항
- [x] 로컬에서 정상 동작 확인
  - 프로필 편집 중 이미지 업로드/리셋 후에도 introTitle / introContent 입력값 유지
- [x] 타입 에러 없음
- [x] 기존 기능 정상 동작 유지
  - 프로필 수정 저장, 이미지 업로드/리셋, 마이페이지 렌더링 정상
- [x] 불필요한 API 호출 없음
  - 이미지 리셋 시 사용자 정보 재조회 API 제거

## 📝 비고
- 현재는 프론트엔드에서 이미지 변경과 텍스트 편집 상태를 분리하여 관리하도록 개선한 상태입니다.
